### PR TITLE
collected commit for merging Stamps with LabelConnector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 extras/.DS_Store
 .DS_Store
 *.dat
+.venv
+.vscode
+pyproject.toml

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ Here is a quick summary of the changes made to the original code:
 - search and create like Nuke Nodes (Character-based matching, hit Tab/Enter to create)
 - Support for colored Anchors and Backdrops
 - disable/hide Anchors (e.g. you import another nukescript as reference)
+- **CTRL+SHIFT+Drop Node** to swap nodes preserves connections
 - performance improvements
 
 ### new Shortcuts
+
 within the new GUI:
+
 - **RIGHT CLICK** to preview with Viewer (resets Viewer on close)
 - **SHIFT+CLICK:** select and create multiple Stamps
 - **ALT+CLICK:** open color quick menu to colorize Anchor
@@ -17,6 +20,7 @@ within the new GUI:
 - **CTRL+ALT+CLICK:** jump/cycle through Stamps
 
 and outside the GUI:
+
 - **CTRL+STAMPS_SHORTCUT:** with one or multiple Anchors selected, set a new color
 - **CTRL+STAMPS_SHORTCUT:** with Stamp selected, will jump to it's anchor
 - **SHIFT+STAMPS_SHORTCUT:** with one or multiple Anchors or Stamps selected, will select all stamps of their/that anchor

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+## Stamps for Nuke with alternative GUI
+
+Here is a quick summary of the changes made to the original code:
+
+- new GUI to set up new Node Connections
+- search and create like Nuke Nodes (Character-based matching, hit Tab/Enter to create)
+- Support for colored Anchors and Backdrops
+- disable/hide Anchors (e.g. you import another nukescript as reference)
+- performance improvements
+
+### new Shortcuts
+within the new GUI:
+- **RIGHT CLICK** to preview with Viewer (resets Viewer on close)
+- **SHIFT+CLICK:** select and create multiple Stamps
+- **ALT+CLICK:** open color quick menu to colorize Anchor
+- **CTRL+CLICK:** jumps to Anchor or Category (also works on top row of UI)
+- **CTRL+ALT+CLICK:** jump/cycle through Stamps
+
+and outside the GUI:
+- **CTRL+STAMPS_SHORTCUT:** with one or multiple Anchors selected, set a new color
+- **CTRL+STAMPS_SHORTCUT:** with Stamp selected, will jump to it's anchor
+- **SHIFT+STAMPS_SHORTCUT:** with one or multiple Anchors or Stamps selected, will select all stamps of their/that anchor
+- **D:** disable (hide) Anchors. They won't show up in the new UI.
+
+#### new GUI 
+
+![Stamps Example 1](https://lukasschwabe.com/wp-content/uploads/2024/04/stamps_example1.png)
+(Tag Categories left, Backdrop Categories right)
+
+#### Create multiple Stamps
+
+![Stamps Example 5](https://lukasschwabe.com/wp-content/uploads/2024/04/stamps_example5.png)
+
+#### Show all Connections
+
+![Stamps Example 2](https://lukasschwabe.com/wp-content/uploads/2024/04/stamps_example2.png)
+
+#### Set color (works with multiple Anchors selected)
+
+![Stamps Example 3](https://lukasschwabe.com/wp-content/uploads/2024/04/stamps_example3.png)
+
+#### Jump to Anchor/Category
+
+![Stamps Example 4](https://lukasschwabe.com/wp-content/uploads/2024/04/stamps_example4.png)
+
+### Known issues
+
+To properly support colored Anchors and Stamps (red font for broken connections, nicer formatting), we had to utilize HTML for the autolabel. Unfortunately, Nuke behaves a bit funky with those. If you zoom in/out in the DAG, you'll notice that the last character sometimes flips into a new line. We haven't found a way to work around this, I opened a bug report, let's hope for the best :) -> [Bug Report (Foundry Account required)](https://support.foundry.com/hc/en-us/articles/18657215784978-ID-575964-The-formatting-on-a-nodes-autolabel-breaks-at-certain-zoom-levels-in-the-Node-Graph)

--- a/changelogStamps2.0.txt
+++ b/changelogStamps2.0.txt
@@ -1,0 +1,51 @@
+Changelog Stamps 2.0
+
+Merging Stamps v1.1 with Labelconnector v1.5
+
+changes to Stamps itself:
+
+- changed the text on anchors/stamps to html to be able to colorize parts differently
+- added new callbacks to ensure hide/disable functionality pressing D on Anchors (and preserving it's state with saving/loading)
+- disabled PostageStamps by default. Defaulting to NoOps now.
+- added jumpORcolor(), showConnections(), jumpKeepingPreviousSelection(), change_color_on_anchors()
+- removed the check for name duplicates when creating new anchors/stamps. Nuke can do it by default with the node.setName() super fast. This improves speed quite tremendously! Collisions are still nto a problem, the new Anchor name might be just one digit apart, but that is as "collision proof" as any other random name when copying to another script.
+- made some changes so the "drag node with ctrl-shift onto another node to switch their places" works now with stamps as well, without loosing their proper connections
+- added USE_LABELCONNECTOR_UI constant to stamps_config.py to be able to switch between the old and new UI
+- added the functionality to also derive different default colors based on e.g. naming, category, ... similar to default tags
+- disabled all processing in the DeepExpression nodes used as stamps/anchors
+- changed "except" to "except Exception" to comply with these new Python 3 guidelines
+
+new UI:
+
+- implemented UI from LabelConnector
+    - adjusted UI to fit Stamps with Categories derived from Tags and/or Backdrops
+    - Top row will show all categories, Tags on the left, Backdrops on the right
+    - remembers previously selected category
+
+    - character based search (similar to Nuke Node Menu, e.g. "rc" can resolve "Roto Character")
+    - search is case insensitive
+    - tab or enter creates top result
+    - it always searches amongst all anchors, not just the selected category
+
+- implemented Color UI from LabelConnector
+    - ctrl+STAMPS_SHORTCUT with one or multiple Anchors selected
+    - quickly change color of selected anchor
+    - color will be changed on all stamps accordingly
+    - COLOR_LIST in labelConnectorForStamps.py can be adjusted to your liking
+
+new shortcuts (to make these even more handy, we have stamps on "E" by default. We didn't change the default in this version though, it's F8)
+
+    in the new UI:
+    - right click: temporarily set viewer to that anchor (click again or closing UI reverts to previous state)
+    - shift+click: select and create multiple
+    - alt+click: open color quick menu to colorize anchor
+    - ctrl+click: jumps to anchor or category (also works on top row of UI)
+    - ctrl+alt+click: jump/cycle through stamps
+
+    outside of the UI:
+    - ctrl+STAMPS_SHORTCUT: with one or multiple Anchors selected, set a new color
+    - ctrl+STAMPS_SHORTCUT: with Stamp selected, will jump to it's anchor
+    - shift+STAMPS_SHORTCUT: with one or multiple anchors or stamps selected, will select all stamps of their/that anchor
+    - D: disable (hide) anchors. They won't show up in the new UI. (e.g. you load a different shot as ref into your comp)
+
+

--- a/stamps/labelConnectorForStamps.py
+++ b/stamps/labelConnectorForStamps.py
@@ -871,7 +871,7 @@ class LabelConnector(QtGuiWidgets.QWidget):
         """
 
         # hide the main widget while we alter the grid, as each setVisible(True) call triggers a repaint
-        self.main_widget.setVisible(False)
+        # self.main_widget.setVisible(False)
 
         inputText = self.input.text()
 
@@ -894,7 +894,7 @@ class LabelConnector(QtGuiWidgets.QWidget):
             for button in self.highlighted_buttons:
                 button.setStyleHighlighted()
 
-        self.main_widget.setVisible(True)
+        # self.main_widget.setVisible(True)
 
     def keyPressEvent(self, event):
         if event.key() == QtCore.Qt.Key_Escape:

--- a/stamps/labelConnectorForStamps.py
+++ b/stamps/labelConnectorForStamps.py
@@ -1,0 +1,1382 @@
+"""
+labelConnector v2.0 - 09/2023
+Lukas Schwabe
+Provides context-based UI helpers to setup and navigate Node Connections in Nuke.
+Now merged with the base of Stamps, using the Label Connector UI.
+"""
+
+__version__ = 2.0
+
+import fnmatch
+import math
+import re
+import textwrap
+
+import nuke
+import PySide2.QtCore as QtCore
+import PySide2.QtGui as QtGui
+import PySide2.QtWidgets as QtGuiWidgets
+import stamps
+
+try:
+    import stamps_config
+except Exception:
+    pass
+
+BUTTON = "border-radius: 5px; font: 13px; padding: 4px 7px;"
+BUTTON_SELECTED = "border-radius: 5px; font: 13px; font-weight: bold; padding: 4px 7px;"
+BUTTON_BORDER_DEFAULT = "border: 1px solid #181818;"
+BUTTON_BORDER_HIGHLIGHT = "border: 1px solid #AAAAAA;"
+BUTTON_BORDER_SELECTED = "border: 1px solid #C6710C;"
+BUTTON_REGULAR_COLOR = 673720575
+BUTTON_REGULARDARK_COLOR = "#1c1f22"
+BUTTON_REGULARMID_COLOR = "#212329"
+BUTTON_HIGHLIGHT_COLOR = "#C6710C"
+
+SEARCHFIELD = "border-radius: 5px; font: 13px; border: 1px solid #181818;"
+
+MAX_COLUMNS_ALL_TAGS = 10
+MAX_COLUMNS_ALL_ANCHORS = 12
+MAX_CHARS_ANCHOR_BUTTONS = 16  # linebreak after this amount of characters
+CONNECTORMINIMUMHEIGHT = 500  # UI minimun height in px
+
+UNDO = nuke.Undo()
+
+_labelConnectorUI = None
+_last_used_tag = {"name": "", "is_backdrop_tag": False}
+
+# List of UI colors for the color selection UI
+COLOR_LIST = {
+    "Red": 1277436927,
+    "Orange": 2017657087,
+    "Yellow": 2154504703,
+    "Green": 793519103,
+    "Dark Green": 304619007,
+    "Cyan": 592071935,
+    "Blue": 556482559,
+    "Dark Blue": 320482047,
+    "Purple": 975388415,
+    "Default": BUTTON_REGULAR_COLOR,
+}
+
+
+class TagBackdropButton(QtGuiWidgets.QPushButton):
+    """Class for the buttons on top of the UI that filter the Anchor Buttons by Tags/Backdrops."""
+
+    def __init__(self, text, color="", is_backdrop_tag=False, parent=None):
+        """Class for the buttons on top of the UI that filter the Anchor Buttons by Tags/Backdrops.
+
+        Args:
+            text (str): Button name
+            is_backdrop_tag (bool): True if this is a backdrop tag, False if it's a regular tag.
+            parent (QObject, optional): parent widget. Defaults to None.
+        """
+
+        super(TagBackdropButton, self).__init__(parent)
+
+        self.color = color or BUTTON_REGULARDARK_COLOR
+        self.highlight = BUTTON_HIGHLIGHT_COLOR
+        self.selected = False
+
+        self.is_backdrop_tag = is_backdrop_tag
+
+        self.highlighted_style = (
+            "QPushButton{background-color:"
+            + self.color
+            + ";"
+            + BUTTON_SELECTED
+            + BUTTON_BORDER_HIGHLIGHT
+            + "} "
+            + "QPushButton:hover{background-color:"
+            + self.highlight
+            + ";"
+            + BUTTON_SELECTED
+            + BUTTON_BORDER_HIGHLIGHT
+            + "}"
+        )
+
+        self.default_style = (
+            "QPushButton{background-color:"
+            + self.color
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_DEFAULT
+            + "} "
+            + "QPushButton:hover{background-color:"
+            + self.highlight
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_DEFAULT
+            + "}"
+        )
+
+        self.setText(text)
+        self.setFixedHeight(45)
+        self.setMinimumWidth(145)
+        self.setMaximumWidth(200)
+        self.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setMouseTracking(True)
+
+        self.setStyleDefault()
+
+    def setStyleHighlighted(self):
+        """Style used when this filter is active."""
+
+        self.selected = True
+        self.setStyleSheet(self.highlighted_style)
+
+    def setStyleDefault(self):
+        """default style."""
+
+        self.selected = False
+        self.setStyleSheet(self.default_style)
+
+
+class AnchorButton(QtGuiWidgets.QPushButton):
+    """Class for the buttons that represent the Anchors. Emitting a signal when right clicked."""
+
+    rightClicked = QtCore.Signal()
+
+    def __init__(self, anchor, parent=None):
+        """Class for the buttons that represent the Anchors. Emitting a signal when right clicked.
+
+        Args:
+            anchor (node): Stores the Anchor node, retreiving button name from the title knob.
+            parent (QObject, optional): parent widget. Defaults to None.
+        """
+
+        super(AnchorButton, self).__init__(parent)
+
+        # self.label = anchor.knob('title').value()
+        self.label = anchor.knob("title").value()
+        self.wrapped_label = "\n".join(textwrap.wrap(anchor.knob("title").value(), width=MAX_CHARS_ANCHOR_BUTTONS))
+        self.anchor = anchor
+        self.tags = []
+        self.backdrop_tags = []
+        self.entered = False  # stores if mouse is hovering above button, to change name with keypresses
+        self.color = rgb2hex(interface2rgb(getTileColor(anchor)))
+        self.highlight = BUTTON_HIGHLIGHT_COLOR
+
+        self.is_highlighted = False  # stores highlight state in case of being selected, to revert correctly
+
+        self.highlighted_style = (
+            "QPushButton{background-color:"
+            + self.color
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_HIGHLIGHT
+            + "} "
+            + "QPushButton:hover{background-color:"
+            + self.highlight
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_HIGHLIGHT
+            + "}"
+        )
+
+        self.default_style = (
+            "QPushButton{background-color:"
+            + self.color
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_DEFAULT
+            + "} "
+            + "QPushButton:hover{background-color:"
+            + self.highlight
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_DEFAULT
+            + "}"
+        )
+
+        self.selected_style = (
+            "QPushButton{background-color:"
+            + self.color
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_SELECTED
+            + "} "
+            + "QPushButton:hover{background-color:"
+            + self.highlight
+            + ";"
+            + BUTTON
+            + BUTTON_BORDER_SELECTED
+            + "}"
+        )
+
+        self.setFixedHeight(65)
+        self.setMinimumWidth(110)
+        self.setMaximumWidth(160)
+        self.setSizePolicy(QtGuiWidgets.QSizePolicy.MinimumExpanding, QtGuiWidgets.QSizePolicy.Fixed)
+
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setMouseTracking(True)
+
+        self.setTextDefault()
+        self.setStyleDefault()
+
+    def mousePressEvent(self, event):
+        """Emits a signal when right clicked."""
+
+        if event.button() == QtCore.Qt.RightButton:
+            self.rightClicked.emit()
+        super(AnchorButton, self).mousePressEvent(event)
+
+    def setStyleHighlighted(self):
+        """In case of a search pattern match."""
+
+        self.setStyleSheet(self.highlighted_style)
+        self.is_highlighted = True
+
+    def setStyleDefault(self):
+        """Default style."""
+
+        self.setStyleSheet(self.default_style)
+        self.is_highlighted = False
+
+    def setStyleSelected(self):
+        """In case of being selected to create multiple stamps."""
+
+        self.setStyleSheet(self.selected_style)
+
+    def enterEvent(self, event):
+        """Change name with modifiers when mouse enters button."""
+
+        keyModifier = QtGuiWidgets.QApplication.keyboardModifiers()
+
+        if keyModifier == QtCore.Qt.ShiftModifier:
+            self.setTextSelect()
+
+        elif keyModifier == QtCore.Qt.AltModifier:
+            self.setTextModify()
+
+        elif keyModifier == QtCore.Qt.ControlModifier:
+            self.setTextJumpAnchor()
+
+        elif keyModifier == QtCore.Qt.ControlModifier | QtCore.Qt.AltModifier:
+            self.setTextJumpStamp()
+
+        self.entered = True
+
+    def leaveEvent(self, event):
+        """Change reset name when mouse leaves button."""
+
+        self.setTextDefault()
+        self.entered = False
+
+    def setTextJumpAnchor(self):
+        self.setText("Jump to Anchor\n-\n" + self.wrapped_label)
+
+    def setTextJumpStamp(self):
+        self.setText("Jump to Stamp\n-\n" + self.wrapped_label)
+
+    def setTextModify(self):
+        self.setText("Colorize...\n-\n" + self.wrapped_label)
+
+    def setTextSelect(self):
+        self.setText("Create multiple\n-\n" + self.wrapped_label)
+
+    def setTextDefault(self):
+        self.setText(self.wrapped_label)
+
+
+class ColorButton(QtGuiWidgets.QPushButton):
+    """Custom QPushButton to build the UI for Color Picking."""
+
+    def __init__(self, text, color=BUTTON_REGULAR_COLOR, parent=None):
+        """Custom QPushButton to build the UI for Color Picking.
+
+        Args:
+            text (str): Name of the button.
+            color (int, optional): Button color in Nukes int format used in the DAG. Defaults to BUTTON_REGULAR_COLOR.
+            parent (QObject, optional): parent widget. Defaults to None.
+
+        """
+        super(ColorButton, self).__init__(parent)
+
+        self.setText(text)
+
+        self.setMinimumWidth(100)
+        self.setMaximumWidth(150)
+        self.setFixedHeight(65)
+        self.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+
+        self.interfaceColor = color
+
+        self.color = rgb2hex(interface2rgb(color))  # converting color to hex
+        self.highlight = BUTTON_HIGHLIGHT_COLOR  # highlight color for mouse hover
+        self.setStyleSheet(
+            "QPushButton{background-color:" + self.color + ";" + BUTTON + "} " + "QPushButton:hover{background-color:" + self.highlight + ";" + BUTTON + "}"
+        )
+
+
+class AnchorModel(QtCore.QStringListModel):
+    """Class to extend the QAbstractListModel to store the Anchor full name in the model."""
+
+    AnchorRole = QtCore.Qt.UserRole + 1
+
+    def __init__(self, data, parent=None):
+        """Class to extend the QAbstractListModel to store the Anchor node in the model.
+
+        Args:
+            data (dict): Dict containing {"name": "anchor_title", "anchor": "anchor_name"}
+            parent (QObject, optional): parent widget. Defaults to None.
+        """
+        super(AnchorModel, self).__init__(parent)
+        self.setStringList(data)
+
+    def setStringList(self, data):
+        """Update the model with the data.
+
+        Args:
+            data (dict): Dict containing {"name": "anchor_title", "anchor": "anchor_name"}
+        """
+
+        self._data = data
+
+        anchor_names = [d["name"] for d in data]
+        super(AnchorModel, self).setStringList(anchor_names)
+
+    def data(self, index, role=QtCore.Qt.DisplayRole):
+        """Extend the data method to return the Anchor node.
+
+        Args:
+            index (PySide2.QtCore.QModelIndex): Index of requested data.
+            role (int, optional): Requested data role. Defaults to QtCore.Qt.DisplayRole.
+
+        Returns:
+            Any
+        """
+
+        if not self._data:
+            return super(AnchorModel, self).data(index, role)
+
+        if role == self.AnchorRole:
+            return self._data[index.row()]["anchor"]
+
+        return super(AnchorModel, self).data(index, role)
+
+    def roleNames(self):
+        roles = super(AnchorModel, self).roleNames()
+        roles[self.AnchorRole] = b"anchor"
+        return roles
+
+
+class AnchorAbstractView(QtGuiWidgets.QListView):
+    """Extend the QListView to emit a signal when the current index changes."""
+
+    currentIndexChanged = QtCore.Signal()
+
+    def currentChanged(self, current, previous):
+        ret = super(AnchorAbstractView, self).currentChanged(current, previous)
+        self.currentIndexChanged.emit()
+        return ret
+
+
+class LineEditConnectSelection(QtGuiWidgets.QLineEdit):
+    """Custom QLineEdit with combined auto completion. Emitting a signal when the model changes."""
+
+    modelChanged = QtCore.Signal()
+
+    def __init__(self, parent=None):
+        """Custom QLineEdit with combined auto completion. Emitting a signal when the model changes.
+
+        Args:
+            parent (QObject, optional): parent widget. Defaults to None.
+        """
+
+        super(LineEditConnectSelection, self).__init__(parent)
+
+        self.filtered_anchor_name_list = []
+        self.setStyleSheet(SEARCHFIELD)
+
+        self.setFixedSize(150, 65)
+        self.setSizePolicy(QtGuiWidgets.QSizePolicy.Fixed, QtGuiWidgets.QSizePolicy.Fixed)
+
+        self.completer = QtGuiWidgets.QCompleter(self.filtered_anchor_name_list, self)
+        self.completer.setCompletionMode(QtGuiWidgets.QCompleter.UnfilteredPopupCompletion)
+        self.completer.setModel(AnchorModel(self.filtered_anchor_name_list))
+
+        self.completer.setPopup(AnchorAbstractView())
+        self.completer.popup().setMouseTracking(True)
+
+        self.item_delegate = QtGuiWidgets.QStyledItemDelegate(self)  # this allows hover highlighting in the popup
+        self.completer.popup().setItemDelegate(self.item_delegate)
+        self.completer.popup().setStyleSheet("QAbstractItemView:item:hover{background-color:#484848;}")
+
+        self.completer.popup().setMinimumHeight(70)
+        self.completer.popup().setMinimumWidth(100)
+        self.completer.popup().setMaximumWidth(150)
+        self.completer.popup().setSizePolicy(
+            QtGuiWidgets.QSizePolicy.MinimumExpanding,
+            QtGuiWidgets.QSizePolicy.MinimumExpanding,
+        )
+
+        self.setCompleter(self.completer)
+
+    def updateCompleterList(self):
+        self.completer.model().setStringList(self.filtered_anchor_name_list)
+
+        # the next line fixes a bug where the completer popup would not show up with just one character types
+        self.completer.popup().show()
+
+        # this next line fixes a bug where the popup won't show up a second time when no anchor buttons shown
+        self.completer.popup().setStyleSheet("QAbstractItemView:item:hover{background-color:#484848;}")
+
+        self.completer.popup().setCurrentIndex(self.completer.model().index(-1, -1))
+        self.modelChanged.emit()
+
+    def focusNextPrevChild(self, next):
+        """overriding this, to be able to use TAB as ENTER, like the Nuke Node Menu"""
+
+        return False
+
+
+class LabelConnector(QtGuiWidgets.QWidget):
+    """Core LabelConnector UI."""
+
+    def __init__(self, all_anchors):
+        """Main Connector UI.
+
+        Args:
+            all_anchors (list[node]): A list containing all anchor nodes in the DAG.
+        """
+
+        super(LabelConnector, self).__init__()
+
+        self.all_anchors = all_anchors
+
+        self.all_anchors.sort(key=lambda anchor: anchor.knob("title").value())  # sort by title
+
+        self.anchorbuttons_by_tags = dict()
+        self.anchor_dict_keys_sorted = list()
+        self.anchorbuttons_by_backdrop_tags = dict()
+
+        self.shiftPressed = False
+        self.ctrlPressed = False
+        self.altPressed = False
+
+        # self.centered_ui = False
+        self.changed_viewed_node = False
+
+        global _last_used_tag
+        self.current_view_filter = _last_used_tag
+
+        self.tag_buttons = list()
+        self.anchor_buttons = list()
+        self.current_anchor_grid_buttons = list()
+        self.current_anchor_grid_spacers = list()
+        self.clicked_anchors_list = list()
+
+        try:  # we have to try this in case no viewer exists or no active input is used
+            self.current_viewed_node = nuke.activeViewer().node().input(nuke.activeViewer().activeInput())
+        except Exception:
+            self.current_viewed_node = None
+
+        try:
+            self.active_viewer_input = nuke.activeViewer().activeInput()  # returns None if nothing is connected
+        except Exception:
+            self.active_viewer_input = None
+
+        if self.active_viewer_input is None:
+            # if there was no input, we set it to 1 (which equals to Num2 in Nuke, to avoid the first input)
+            self.active_viewer_input = 1
+
+        # main layout
+        self.main_widget = QtGuiWidgets.QWidget(self)
+        self.main_layout = QtGuiWidgets.QVBoxLayout(self)
+        self.quadrant_layout = QtGuiWidgets.QGridLayout(self)
+        self.quadrant_layout.setColumnStretch(0, 1)
+        self.quadrant_layout.setColumnStretch(1, 0)
+        self.quadrant_layout.setRowStretch(0, 0)
+        self.quadrant_layout.setRowStretch(1, 1)
+        self.quadrant_layout.setRowStretch(2, 0)
+        self.quadrant_layout.setSpacing(20)
+
+        # grid for the Tag/Backdrop Buttons
+        self.tags_grid = QtGuiWidgets.QGridLayout(self)
+        self.tags_grid.setSpacing(5)
+
+        # grid for the Anchor Buttons
+        self.anchors_grid = QtGuiWidgets.QGridLayout(self)
+        self.anchors_grid.setSpacing(5)
+
+        # vertical layout for the search field and completer
+        self.completer_vlayout = QtGuiWidgets.QVBoxLayout(self)
+        self.completer_vlayout.setSpacing(5)
+        self.completer_vlayout.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+
+        self.prepare_all_anchors_and_tags()
+
+        # populate the Tag/Backdrop Buttons grid
+        self.populate_tag_grid()
+
+        # search field and completer
+        self.input = LineEditConnectSelection()
+        self.input.textEdited.connect(self.updateSearchMatches)
+        self.input.returnPressed.connect(self.lineEnter)
+        self.input.modelChanged.connect(self.highlightButtonsMatchingResults)
+        self.input.completer.popup().currentIndexChanged.connect(self.highlightButtonsMatchingResults)
+        self.input.completer.popup().pressed.connect(self.lineEnter)
+
+        self.completer_vlayout.addWidget(self.input, QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+        self.completer_vlayout.addWidget(self.input.completer.popup(), QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+        self.completer_vlayout.setStretch(0, 0)
+        self.completer_vlayout.setStretch(1, 1)
+
+        # populate the Anchor Buttons grid
+        self.populate_anchors_grid()
+
+        # explanation label at the bottom
+        explanation_label = QtGuiWidgets.QLabel(self)
+        explanation_label.setText("shift - multiple | alt - colorize | ctrl(+alt) - jump anchor(stamp) | right-click - preview")
+        explanation_label.setStyleSheet("color: #AAAAAA; font: 10px;")
+        explanation_label.setWordWrap(True)
+        explanation_label.setAlignment(QtCore.Qt.AlignCenter)
+
+        self.quadrant_layout.addLayout(self.tags_grid, 0, 0, QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+        self.quadrant_layout.addLayout(self.completer_vlayout, 1, 1, QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+        self.quadrant_layout.addLayout(self.anchors_grid, 1, 0, QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+        self.quadrant_layout.addWidget(explanation_label, 2, 0, QtCore.Qt.AlignTop)
+
+        # add mainwidget to the layout
+        self.main_widget.setLayout(self.quadrant_layout)
+        self.main_widget.setSizePolicy(
+            QtGuiWidgets.QSizePolicy.MinimumExpanding,
+            QtGuiWidgets.QSizePolicy.MinimumExpanding,
+        )
+        self.main_widget.setObjectName("main_widget")
+        self.main_widget.setStyleSheet("QWidget#main_widget{background-color: rgba(45, 45, 45, 0.9);}")
+        self.main_layout.addWidget(self.main_widget)
+
+        self.setLayout(self.main_layout)
+        self.setSizePolicy(QtGuiWidgets.QSizePolicy.Preferred, QtGuiWidgets.QSizePolicy.Preferred)
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.WindowStaysOnTopHint)
+        # self.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+
+        self.installEventFilter(self)
+
+        self.input.setFocus()
+
+    def populate_tag_grid(self):
+        """Populate the Tag/Backdrop Buttons grid. It balances a split between the two."""
+
+        total_amount_categories = len(self.anchorbuttons_by_tags) + len(self.anchorbuttons_by_backdrop_tags)
+        self.anchors_grid_width = min(
+            max(
+                math.ceil(math.sqrt(float(len(self.all_anchors)))),
+                total_amount_categories,
+            ),
+            MAX_COLUMNS_ALL_ANCHORS - 1,
+        )
+
+        column_counter, row_counter = 0, 0
+
+        max_columns = MAX_COLUMNS_ALL_TAGS
+        max_anchor_tag_columns = max(
+            int((len(self.anchorbuttons_by_tags) / float(total_amount_categories)) * max_columns),
+            1,
+        )
+
+        tag_button = TagBackdropButton("All Anchors", parent=self)
+        tag_button.clicked.connect(self.tag_button_clicked)
+
+        self.tags_grid.addWidget(tag_button, 0, column_counter)
+        self.tag_buttons.append(tag_button)
+        column_counter += 1
+
+        for tag in sorted(self.anchorbuttons_by_tags.keys()):
+            try:
+                color_from_pipe = stamps_config.getColorFromTags(tag)
+            except Exception:
+                color_from_pipe = None
+
+            if color_from_pipe:
+                color_from_pipe = rgb2hex(interface2rgb(color_from_pipe))
+
+            tag_button = TagBackdropButton(tag, color=color_from_pipe, parent=self)
+
+            tag_button.clicked.connect(self.tag_button_clicked)
+            self.tags_grid.addWidget(tag_button, row_counter, column_counter)
+            self.tag_buttons.append(tag_button)
+            column_counter += 1
+            if column_counter > (max_anchor_tag_columns - 1):
+                row_counter += 1
+                column_counter = 0
+
+        if self.anchorbuttons_by_backdrop_tags:
+            column_counter, row_counter = max_anchor_tag_columns + 1, 0
+
+            # this is a quick'n'dirty solution, but we have to pick n choose somehow anyways in case of multiple backdrops
+            backdrops = nuke.allNodes("BackdropNode")
+
+            for tag in sorted(self.anchorbuttons_by_backdrop_tags.keys()):
+                # continuing the quick'n'dirty approach, just picking the first backdrop with the tag
+                for backdrop in backdrops:
+                    if backdrop["label"].value() == tag:
+                        color_from_backdrop = rgb2hex(interface2rgb(backdrop["tile_color"].value()))
+                        break
+
+                tag_button = TagBackdropButton(tag, color=color_from_backdrop, is_backdrop_tag=True, parent=self)
+                tag_button.clicked.connect(self.tag_button_clicked)
+                self.tags_grid.addWidget(tag_button, row_counter, column_counter)
+                self.tag_buttons.append(tag_button)
+                column_counter += 1
+                if column_counter > (max_columns):
+                    row_counter += 1
+                    column_counter = max_anchor_tag_columns + 1
+
+            column_counter, row_counter = max_anchor_tag_columns, 0
+
+            # add a divider line between the two tag categories
+            spacer = QtGuiWidgets.QLabel(self)
+            spacer.setFixedWidth(1)
+            spacer.setSizePolicy(QtGuiWidgets.QSizePolicy.Fixed, QtGuiWidgets.QSizePolicy.Expanding)
+            spacer.setStyleSheet("background-color: black; border: 1px solid grey;")
+
+            self.tags_grid.addWidget(spacer, row_counter, column_counter, self.tags_grid.rowCount(), 1)
+
+    def prepare_all_anchors_and_tags(self):
+        """create all anchor buttons and store them in a dict by tags."""
+
+        for anchor in self.all_anchors:
+            button = AnchorButton(anchor, self)
+            button.clicked.connect(self.anchor_button_clicked)
+            button.rightClicked.connect(self.anchor_button_right_clicked)
+
+            tags_value = anchor["tags"].value().strip()
+            # Remove leading/trailing spaces and separate by commas (with or without spaces)
+            tags = [tag for tag in re.split(" *, *", tags_value.strip()) if tag]
+
+            # make sure we don't loose nodes that don't have a Tag at all
+            if not tags:
+                tags = ["No Tag"]
+
+            backdrop_tags = stamps.backdropTags(anchor)
+
+            button.tags = tags  # store all tags in the button
+            button.backdrop_tags = backdrop_tags
+
+            # accumulate all tags in a dict containing all buttons with the same tag
+            for tag in tags:
+                self.anchorbuttons_by_tags.setdefault(tag, []).append(button)
+
+            for tag in backdrop_tags:
+                self.anchorbuttons_by_backdrop_tags.setdefault(tag, []).append(button)
+
+            self.anchor_buttons.append(button)
+
+        self.anchor_dict_keys_sorted = list(self.anchorbuttons_by_tags.keys())
+        self.anchor_dict_keys_sorted.sort()
+
+    def populate_anchors_grid(self):
+        """Add the Anchor Buttons to the grid."""
+
+        if self.current_anchor_grid_spacers:
+            for spacer in self.current_anchor_grid_spacers:
+                self.anchors_grid.removeWidget(spacer)
+                spacer.setVisible(False)
+                spacer.setParent(None)
+                spacer.deleteLater()
+
+        self.current_anchor_grid_spacers = []
+        self.current_anchor_grid_buttons = []
+
+        if self.current_view_filter["name"] == "":
+            for anchor_button in self.anchor_buttons:
+                anchor_button.setVisible(False)
+
+            # add a vertical spacer, to force a resize
+            # spacer = QtGuiWidgets.QLabel(self)
+            # spacer.setFixedHeight(1)
+            # spacer.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+            # self.current_anchor_grid_spacers.append(spacer)
+            # self.anchors_grid.addWidget(spacer, 0, 0, 1, self.anchors_grid_width + 1)
+
+        elif self.current_view_filter["name"] == "All Anchors":
+            for anchor_button in self.anchor_buttons:
+                anchor_button.setVisible(True)
+
+            self.first_tag_to_add = True
+
+            self.add_dict_with_spacer(self.anchorbuttons_by_tags)
+
+            # double check if this will ever add sth, think it never will
+            # column_counter, row_counter = self.add_dict_with_spacer(
+            #     column_counter, row_counter, self.anchorbuttons_by_backdrop_tags)
+
+        else:
+            column_counter, row_counter = 0, 0
+
+            is_backdrop_tag = self.current_view_filter["is_backdrop_tag"]
+            query = self.current_view_filter["name"]
+
+            for anchor_button in self.anchor_buttons:
+                tags = anchor_button.backdrop_tags if is_backdrop_tag else anchor_button.tags
+
+                if query in tags:
+                    self.anchors_grid.addWidget(anchor_button, row_counter, column_counter)
+                    self.current_anchor_grid_buttons.append(anchor_button)
+                    anchor_button.setVisible(True)
+                    column_counter += 1
+                    if column_counter > self.anchors_grid_width:
+                        row_counter += 1
+                        column_counter = 0
+
+                else:
+                    anchor_button.setVisible(False)
+
+            row_counter += 1
+            # add a vertical spacer, to force a resize
+            # spacer = QtGuiWidgets.QLabel(self)
+            # spacer.setFixedHeight(1)
+            # spacer.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+            # self.current_anchor_grid_spacers.append(spacer)
+            # self.anchors_grid.addWidget(spacer, row_counter, 0, 1, self.anchors_grid_width + 1)
+
+        for tag_button in self.tag_buttons:
+            if tag_button.is_backdrop_tag == self.current_view_filter["is_backdrop_tag"] and tag_button.text() == self.current_view_filter["name"]:
+                tag_button.setStyleHighlighted()
+            else:
+                tag_button.setStyleDefault()
+
+    def add_dict_with_spacer(self, anchor_dict):
+        """
+        Adds a dict of Anchor Buttons to the grid, adding a spacer line between different tags.
+        Anchors are added only once, so if they are in multiple tags, they won't be added twice.
+        This gives sort of a "tag" grouping in the UI, with out exploding the UI with too many tags.
+        """
+
+        column_counter, row_counter = 0, 0
+
+        for tag in self.anchor_dict_keys_sorted:
+            added_spacer = False
+            added_tags = False
+
+            # add the buttons
+            for anchor_button in anchor_dict[tag]:
+                if anchor_button not in self.current_anchor_grid_buttons:
+                    if not added_spacer and not self.first_tag_to_add:
+                        row_counter = self.add_dict_spacer(row_counter)
+                        added_spacer = True
+
+                    added_tags = True
+
+                    self.anchors_grid.addWidget(anchor_button, row_counter, column_counter)
+                    self.current_anchor_grid_buttons.append(anchor_button)
+                    column_counter += 1
+                    if column_counter > self.anchors_grid_width:
+                        row_counter += 1
+                        column_counter = 0
+
+            if added_tags:
+                self.first_tag_to_add = False
+                row_counter = row_counter + 1
+                column_counter = 0
+
+    def add_dict_spacer(self, row_counter):
+        """Adds the spacer line between different tags."""
+
+        # add a vertical spacer before the line
+        spacer_before = QtGuiWidgets.QLabel(self)
+        spacer_before.setFixedHeight(1)
+        spacer_before.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+        self.current_anchor_grid_spacers.append(spacer_before)
+        self.anchors_grid.addWidget(spacer_before, row_counter, 0, 1, self.anchors_grid_width + 1)
+        row_counter += 1
+
+        # add the line
+        spacer = QtGuiWidgets.QLabel(self)
+        spacer.setFixedHeight(1)
+        spacer.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+        spacer.setStyleSheet("background-color: black; border: 1px solid grey;")
+
+        self.current_anchor_grid_spacers.append(spacer)
+        self.anchors_grid.addWidget(spacer, row_counter, 0, 1, self.anchors_grid_width + 1)
+        row_counter += 1
+
+        # add a vertical spacer after the line
+        spacer_after = QtGuiWidgets.QLabel(self)
+        spacer_after.setFixedHeight(1)
+        spacer_after.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Fixed)
+        self.current_anchor_grid_spacers.append(spacer_after)
+        self.anchors_grid.addWidget(spacer_after, row_counter, 0, 1, self.anchors_grid_width + 1)
+        row_counter += 1
+
+        return row_counter
+
+    def resizeEvent(self, event):
+        """This gets exectued by Qt when the GUI changed size."""
+
+        # the setMinimumHeight method seems to do weird stuff, so lest just do it manually
+        if event.size().height() < CONNECTORMINIMUMHEIGHT:
+            self.resize(self.width(), CONNECTORMINIMUMHEIGHT)
+
+        super(LabelConnector, self).resizeEvent(event)
+
+        screen_center = QtGui.QGuiApplication.screenAt(QtGui.QCursor.pos()).geometry().center()
+
+        geo = self.frameGeometry()
+
+        geo.moveCenter(screen_center)
+        self.move(geo.topLeft())
+
+    def close(self):
+        """Close the UI."""
+
+        try:
+            # if viewer input was changed, we set it back to the original input
+            if self.changed_viewed_node:
+                nuke.activeViewer().node().setInput(self.active_viewer_input, self.current_viewed_node)
+        except Exception:
+            pass
+
+        super(LabelConnector, self).close()
+
+    QtCore.Slot()
+
+    def updateSearchMatches(self):
+        """
+        Searches for matches, filling the list for the completer as well as the highlighting.
+        It matches patterns like the Nuke Node Menu does. Typing "cp" will match "Crypto People" for example.
+        """
+
+        inputText = self.input.text().lower().strip()
+
+        self.input.filtered_anchor_name_list = []
+        self.highlighted_buttons = []
+
+        if inputText:
+            query = "*" + "*".join(inputText) + "*"
+
+            tempListUnsorted = []
+
+            for button in self.anchor_buttons:
+                if fnmatch.fnmatch(button.label.lower(), query):
+                    self.highlighted_buttons.append(button)
+                    tempListUnsorted.append({"name": button.label, "anchor": button.anchor.name()})
+
+            for n in list(tempListUnsorted):
+                if n["name"].startswith(inputText):
+                    self.input.filtered_anchor_name_list.append(n)
+                    tempListUnsorted.remove(n)
+
+            for n in list(tempListUnsorted):
+                if inputText in n["name"]:
+                    self.input.filtered_anchor_name_list.append(n)
+                    tempListUnsorted.remove(n)
+
+            self.input.filtered_anchor_name_list.extend(tempListUnsorted)
+
+        self.input.updateCompleterList()
+
+        # global _last_used_tag
+
+        # if self.current_view_filter["name"] == "":
+        #     self.current_view_filter = {"name": "All Anchors", "is_backdrop_tag": False}
+        #     _last_used_tag = self.current_view_filter
+        #     self.populate_anchors_grid()
+
+    QtCore.Slot()
+
+    def highlightButtonsMatchingResults(self):
+        """
+        Highlights all Buttons matching the search result.
+        Except there is an entry selected, then just this one.
+        """
+
+        inputText = self.input.text()
+
+        for button in self.anchor_buttons:
+            button.setStyleDefault()
+
+        if inputText:
+            selected_entry = self.input.completer.popup().currentIndex()
+
+            if selected_entry.row() != -1:
+                anchor_name = self.input.completer.model().data(selected_entry, QtCore.Qt.UserRole + 1)
+            else:
+                anchor_name = ""
+
+            for button in self.highlighted_buttons:
+                if anchor_name == button.anchor.name() and button.label == inputText:
+                    button.setStyleHighlighted()
+                    return
+
+            for button in self.highlighted_buttons:
+                button.setStyleHighlighted()
+
+    def keyPressEvent(self, event):
+        if event.key() == QtCore.Qt.Key_Escape:
+            self.close()
+            return
+
+        elif event.key() == QtCore.Qt.Key_Tab:
+            self.lineEnter()
+            return
+
+        if event.key() == QtCore.Qt.Key_Control:
+            self.ctrlPressed = True
+
+        elif event.key() == QtCore.Qt.Key_Shift:
+            self.shiftPressed = True
+
+        elif event.key() == QtCore.Qt.Key_Alt:
+            self.altPressed = True
+
+        elif event.key() in [QtCore.Qt.Key_Up, QtCore.Qt.Key_Down]:
+            self.input.completer.popup().keyPressEvent(event)
+
+        if event.key() in [
+            QtCore.Qt.Key_Alt,
+            QtCore.Qt.Key_Shift,
+            QtCore.Qt.Key_Control,
+        ]:
+            self.update_button_text()
+
+    def keyReleaseEvent(self, event):
+        if event.key() == QtCore.Qt.Key_Control:
+            self.ctrlPressed = False
+
+        elif event.key() == QtCore.Qt.Key_Shift:
+            self.shiftPressed = False
+
+            if self.clicked_anchors_list:
+                self.create_multiple_wired()
+                self.close()
+
+        elif event.key() == QtCore.Qt.Key_Alt:
+            self.altPressed = False
+
+        # handle GUI changes for modifier keys
+        if event.key() in [
+            QtCore.Qt.Key_Alt,
+            QtCore.Qt.Key_Shift,
+            QtCore.Qt.Key_Control,
+        ]:
+            self.update_button_text()
+
+    def update_button_text(self):
+        """Set anchors button text based on pressed Modifier Keys."""
+
+        if self.shiftPressed and not (self.altPressed or self.ctrlPressed):
+            for button in self.anchor_buttons:
+                if button.entered:
+                    button.setTextSelect()
+                    break
+
+        elif self.altPressed and not (self.shiftPressed or self.ctrlPressed):
+            for button in self.anchor_buttons:
+                if button.entered:
+                    button.setTextModify()
+                    break
+
+        elif self.ctrlPressed and not (self.shiftPressed or self.altPressed):
+            for button in self.anchor_buttons:
+                if button.entered:
+                    button.setTextJumpAnchor()
+                    break
+
+        elif self.ctrlPressed and self.altPressed and not self.shiftPressed:
+            for button in self.anchor_buttons:
+                if button.entered:
+                    button.setTextJumpStamp()
+                    break
+
+        else:
+            for button in self.anchor_buttons:
+                button.setTextDefault()
+
+    QtCore.Slot()
+
+    def anchor_button_clicked(self):
+        """Clicking actions based on pressed Modifier Keys"""
+
+        keyModifier = QtGuiWidgets.QApplication.keyboardModifiers()
+
+        if keyModifier == QtCore.Qt.ControlModifier:
+            self.jumpKeepingPreviousSelection([self.sender().anchor])
+
+        elif keyModifier == QtCore.Qt.AltModifier:
+            self.close()
+            showColorSelectionUI([self.sender().anchor])
+
+        elif keyModifier == QtCore.Qt.ShiftModifier:
+            anchor_button = self.sender()
+            if anchor_button not in self.clicked_anchors_list:
+                self.clicked_anchors_list.append(anchor_button)
+                anchor_button.setStyleSelected()
+            else:
+                self.clicked_anchors_list.remove(anchor_button)
+                if anchor_button.is_highlighted:
+                    anchor_button.setStyleHighlighted()
+                else:
+                    anchor_button.setStyleDefault()
+
+        elif keyModifier == QtCore.Qt.ControlModifier | QtCore.Qt.AltModifier:
+            anchor_button = self.sender()
+            stamps.wiredZoomNext(anchor_button.anchor.name(), no_error=True)
+
+        else:
+            UNDO.begin("Create Stamp")
+            self.create_wired_node(self.sender().anchor)
+            UNDO.end()
+
+            self.close()
+
+    QtCore.Slot()
+
+    def anchor_button_right_clicked(self):
+        """Set Viewer Input to the clicked Anchor."""
+
+        try:
+            if nuke.activeViewer().node().input(self.active_viewer_input) == self.sender().anchor:
+                nuke.activeViewer().node().setInput(self.active_viewer_input, self.current_viewed_node)
+            else:
+                nuke.activeViewer().node().setInput(self.active_viewer_input, self.sender().anchor)
+                nuke.activeViewer().activateInput(self.active_viewer_input)
+
+            self.changed_viewed_node = True
+
+        except Exception:
+            pass
+
+    def create_wired_node(self, anchor):
+        """Create stamp."""
+
+        return stamps.wired(anchor)
+
+    def create_multiple_wired(self):
+        """Create multiple stamps and place them in x direction."""
+
+        if self.clicked_anchors_list:
+            UNDO.begin("Create Stamps")
+            created_nodes = []
+
+            for anchor_button in self.clicked_anchors_list:
+                n = self.create_wired_node(anchor_button.anchor)
+                created_nodes.append(n)
+
+            xPosFirst = created_nodes[0].xpos()
+            yPosFirst = created_nodes[0].ypos()
+
+            for i, node in enumerate(created_nodes):
+                node.setXpos(xPosFirst + 120 * i)
+                node.setYpos(yPosFirst)
+                node.setSelected(True)
+
+            self.clicked_anchors_list = []
+            UNDO.end()
+
+    QtCore.Slot()
+
+    def tag_button_clicked(self):
+        """Set the current view filter based on the clicked Tag Button."""
+
+        keyModifier = QtGuiWidgets.QApplication.keyboardModifiers()
+
+        if keyModifier == QtCore.Qt.ControlModifier:
+            if self.sender().text() == "All Anchors":
+                nodes = [button.anchor for button in self.anchor_buttons]
+            elif self.sender().is_backdrop_tag:
+                nodes = [button.anchor for button in self.anchorbuttons_by_backdrop_tags[self.sender().text()]]
+            else:
+                nodes = [button.anchor for button in self.anchorbuttons_by_tags[self.sender().text()]]
+
+            self.jumpKeepingPreviousSelection(nodes)
+
+        else:
+            global _last_used_tag
+
+            if self.sender().selected:
+                self.current_view_filter = {"name": "", "is_backdrop_tag": False}
+
+            else:
+                self.current_view_filter = {
+                    "name": self.sender().text(),
+                    "is_backdrop_tag": self.sender().is_backdrop_tag,
+                }
+
+            _last_used_tag = self.current_view_filter
+
+            self.populate_anchors_grid()
+
+    QtCore.Slot()
+
+    def lineEnter(self):
+        """After pressing Enter or Tab"""
+
+        if self.input.text() == "":
+            # self.close()
+            return
+
+        selected_entry = self.input.completer.popup().currentIndex()
+        connect_to = ""
+
+        if selected_entry.row() != -1:
+            anchor_name = self.input.completer.model().data(selected_entry, QtCore.Qt.UserRole + 1)
+            for anchor in self.all_anchors:
+                if anchor_name == anchor.name():
+                    connect_to = anchor
+                    break
+        else:
+            for anchor in self.all_anchors:
+                if self.input.text().lower() == anchor.knob("title").getValue().lower():
+                    connect_to = anchor
+                    break
+
+        if not connect_to and self.input.filtered_anchor_name_list:
+            name_list = [d["name"] for d in self.input.filtered_anchor_name_list]
+            for anchor in self.all_anchors:
+                if name_list[0].lower() == anchor.knob("title").getValue().lower():
+                    connect_to = anchor
+                    break
+
+        if connect_to:
+            keyModifier = QtGuiWidgets.QApplication.keyboardModifiers()
+
+            if keyModifier == QtCore.Qt.ControlModifier:
+                self.jumpKeepingPreviousSelection([connect_to])
+
+            else:
+                self.create_wired_node(connect_to)
+
+        self.close()
+
+    def eventFilter(self, object, event):
+        """Close the UI if it looses focus."""
+
+        if object == self and event.type() in [
+            QtCore.QEvent.WindowDeactivate,
+            QtCore.QEvent.FocusOut,
+        ]:
+            self.create_multiple_wired()
+            self.close()
+            return True
+
+        return False
+
+    def mousePressEvent(self, event):
+        """Close if there was a left click within the UIs geo, but no Button was triggered."""
+
+        if event.button() == QtCore.Qt.LeftButton:
+            self.create_multiple_wired()
+            self.close()
+
+    def jumpKeepingPreviousSelection(self, nodes):
+        """
+        Jump to node without destroyng previous selection of nodes
+
+        Args:
+            nodes (list): any amount of nuke nodes as list
+        """
+
+        if not nodes:
+            return
+
+        prevNodes = nuke.selectedNodes()
+
+        for i in prevNodes:
+            i.setSelected(False)
+
+        for node in nodes:
+            node.setSelected(True)
+
+        nuke.zoomToFitSelected()
+
+        for node in nodes:
+            node.setSelected(False)
+
+        for i in prevNodes:
+            i.setSelected(True)
+
+
+class LabelConnectorColorSelection(QtGuiWidgets.QWidget):
+    """Color Selection UI."""
+
+    def __init__(self, list_of_anchors):
+        """Color Selection UI.
+
+        Args:
+            list_of_anchors (list[node]): List of nodes to colorize.
+        """
+        super(LabelConnectorColorSelection, self).__init__()
+
+        self.list_of_anchors = list_of_anchors
+        self.centered_ui = False
+
+        grid = QtGuiWidgets.QGridLayout()
+        self.setLayout(grid)
+        self.setSizePolicy(QtGuiWidgets.QSizePolicy.Expanding, QtGuiWidgets.QSizePolicy.Expanding)
+
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.WindowStaysOnTopHint)
+        self.setAttribute(QtCore.Qt.WA_NoSystemBackground)
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+
+        self.installEventFilter(self)
+
+        length = int(len(COLOR_LIST) / 2) - 1
+        column_counter, row_counter = 0, 0
+
+        for color in COLOR_LIST:
+            button = ColorButton(color, COLOR_LIST[color], self)
+            button.clicked.connect(self.setColor)
+            grid.addWidget(button, row_counter, column_counter)
+
+            column_counter += 1
+            if column_counter > length:
+                row_counter += 1
+                column_counter = 0
+
+    def eventFilter(self, object, event):
+        """Close the UI if it looses focus."""
+
+        if object == self and event.type() in [
+            QtCore.QEvent.WindowDeactivate,
+            QtCore.QEvent.FocusOut,
+        ]:
+            self.close()
+            return True
+        return False
+
+    QtCore.Slot()
+
+    def setColor(self):
+        """Click on Color Button"""
+
+        color = self.sender().interfaceColor
+
+        if color == BUTTON_REGULAR_COLOR:
+            color = int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16)
+
+        UNDO.begin("Set Anchor Color")
+
+        for anchor in self.list_of_anchors:
+            anchor.knob("tile_color").setValue(color)
+
+        UNDO.end()
+
+        self.close()
+
+    def resizeEvent(self, event):
+        """This gets exectued by Qt once the GUI is drawn. We know the Gui size now and can center it once around the mouse cursor."""
+
+        super(LabelConnectorColorSelection, self).resizeEvent(event)
+
+        if not self.centered_ui:  # set position only once in the beginning
+            geo = self.frameGeometry()
+            centerTo = QtGui.QCursor.pos()
+
+            # slght offset feels better
+            centerTo -= QtCore.QPoint(0, int(geo.height() * 0.1))
+
+            geo.moveCenter(centerTo)
+            self.move(geo.topLeft())
+
+            self.centered_ui = True
+
+            self.previous_mouse_pos = QtGui.QCursor.pos()
+            self.previous_geo_top_left = geo.center()
+
+
+def interface2rgb(hexValue):
+    """
+    Convert a color stored as a 32 bit value as used by nuke for interface colors to normalized rgb values.
+
+    Special thanks to Falk Hofmann for these!
+    """
+
+    return [(0xFF & hexValue >> i) / 255.0 for i in [24, 16, 8]]
+
+
+def rgb2interface(rgb):
+    """
+    Convert a color stored as rgb values to a 32 bit value as used by nuke for interface colors.
+    """
+
+    if len(rgb) == 3:
+        rgb = rgb + (255,)
+
+    return int("%02x%02x%02x%02x" % rgb, 16)
+
+
+def getTileColor(node=None):
+    """
+    If a node has it's color set automatically, the 'tile_color' knob will return 0.
+    If so, this function will scan through the preferences to find the correct color value.
+    """
+
+    node = node or nuke.selectedNode()
+    interfaceColor = node.knob("tile_color").value()
+
+    if (
+        interfaceColor == 0
+        or interfaceColor == nuke.defaultNodeColor(node.Class())
+        or interfaceColor == 3435973632
+        or interfaceColor == int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16)
+    ):
+        interfaceColor = BUTTON_REGULAR_COLOR
+
+    return interfaceColor
+
+
+def rgb2hex(rgbaValues):
+    """Convert a color stored as normalized rgb values to a hex."""
+
+    if len(rgbaValues) < 3:
+        return
+    return "#%02x%02x%02x" % (
+        int(rgbaValues[0] * 255),
+        int(rgbaValues[1] * 255),
+        int(rgbaValues[2] * 255),
+    )
+
+
+def hex2rgb(hexColor):
+    """Convert a color stored as hex to rgb values."""
+
+    hexColor = hexColor.lstrip("#")
+    return tuple(int(hexColor[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def filter_out_disabled_anchors(all_anchors):
+    """Filter out disabled anchors."""
+
+    filtered_anchors = []
+
+    for anchor in all_anchors:
+        # if the disable knob doesn't exist, add the anchor as it's an old anchor
+        if anchor.knob("disable"):
+            if not anchor.knob("disable").value():
+                filtered_anchors.append(anchor)
+        else:
+            filtered_anchors.append(anchor)
+
+    return filtered_anchors
+
+
+def showConnector(all_anchors):
+    """Entry point for the LabelConnector UI."""
+
+    global _labelConnectorUI
+
+    all_anchors = filter_out_disabled_anchors(all_anchors)
+
+    if not all_anchors:
+        nuke.message("No Anchors to display.")
+        return
+
+    _labelConnectorUI = LabelConnector(all_anchors)
+    _labelConnectorUI.show()
+
+
+def showColorSelectionUI(list_of_anchors):
+    """Entry point for the Color Selection UI."""
+
+    global _labelConnectorUI
+
+    _labelConnectorUI = LabelConnectorColorSelection(list_of_anchors)
+    _labelConnectorUI.show()

--- a/stamps/labelConnectorForStamps.py
+++ b/stamps/labelConnectorForStamps.py
@@ -611,8 +611,7 @@ class LabelConnector(QtGuiWidgets.QWidget):
             column_counter, row_counter = max_anchor_tag_columns + 1, 0
 
             for tag in sorted(self.anchorbuttons_by_backdrop_tags.keys()):
-                
-                backdrop_node = self.anchorbuttons_by_backdrop_tags[tag][0].backdrop_tags[tag] # pick the backdrop node from first anchor
+                backdrop_node = self.anchorbuttons_by_backdrop_tags[tag][0].backdrop_tags[tag]  # pick the backdrop node from first anchor
                 color_from_backdrop = rgb2hex(interface2rgb(backdrop_node["tile_color"].value()))
 
                 tag_button = TagBackdropButton(tag, color=color_from_backdrop, is_backdrop_tag=True, parent=self)
@@ -670,6 +669,9 @@ class LabelConnector(QtGuiWidgets.QWidget):
     def populate_anchors_grid(self):
         """Add the Anchor Buttons to the grid."""
 
+        # hide the main widget while we alter the grid, as each setVisible(True) call triggers a repaint
+        self.main_widget.setVisible(False)
+
         if self.current_anchor_grid_spacers:
             for spacer in self.current_anchor_grid_spacers:
                 self.anchors_grid.removeWidget(spacer)
@@ -714,12 +716,14 @@ class LabelConnector(QtGuiWidgets.QWidget):
                     anchor_button.setVisible(False)
 
             row_counter += 1
-            
+
         for tag_button in self.tag_buttons:
             if tag_button.is_backdrop_tag == self.current_view_filter["is_backdrop_tag"] and tag_button.text() == self.current_view_filter["name"]:
                 tag_button.setStyleHighlighted()
             else:
                 tag_button.setStyleDefault()
+
+        self.main_widget.setVisible(True)
 
     def add_dict_with_spacer(self, anchor_dict):
         """
@@ -866,6 +870,9 @@ class LabelConnector(QtGuiWidgets.QWidget):
         Except there is an entry selected, then just this one.
         """
 
+        # hide the main widget while we alter the grid, as each setVisible(True) call triggers a repaint
+        self.main_widget.setVisible(False)
+
         inputText = self.input.text()
 
         for button in self.anchor_buttons:
@@ -886,6 +893,8 @@ class LabelConnector(QtGuiWidgets.QWidget):
 
             for button in self.highlighted_buttons:
                 button.setStyleHighlighted()
+
+        self.main_widget.setVisible(True)
 
     def keyPressEvent(self, event):
         if event.key() == QtCore.Qt.Key_Escape:

--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -308,10 +308,10 @@ def wiredKnobChanged():
     elif kn == "title":
         kv = k.value()
         if titleIsLegal(kv):
-            if nuke.ask("Do you want to update the linked stamps' title?"):
-                a = retitleAnchor(n)  # Retitle anchor
-                retitleWired(a)  # Retitle wired stamps of anchor a
-                return
+            # if nuke.ask("Do you want to update the linked stamps' title?"):
+            a = retitleAnchor(n)  # Retitle anchor
+            retitleWired(a)  # Retitle wired stamps of anchor a
+            return
         else:
             nuke.message("Please set a valid title.")
         try:
@@ -420,9 +420,9 @@ def anchorKnobChanged():
     if kn == "title":
         kv = k.value()
         if titleIsLegal(kv):
-            if nuke.ask("Do you want to update the linked stamps' title?"):
-                retitleWired(n)  # Retitle wired stamps of anchor a
-                return
+            # if nuke.ask("Do you want to update the linked stamps' title?"):
+            retitleWired(n)  # Retitle wired stamps of anchor a
+            return
         else:
             nuke.message("Please set a valid title.")
         try:
@@ -1086,7 +1086,9 @@ def wired(anchor):
     backdrops_knob = nuke.Text_Knob("backdrops", "Backdrops:", " ")
     backdrops_knob.setTooltip("Labels of backdrop nodes which contain this stamp's Anchor.")
     postageStamp_knob = nuke.Boolean_Knob("postageStamp_show", "postage stamp")
-    postageStamp_knob.setTooltip("Enable the postage stamp thumbnail in this node.\nYou're seeing this because the class of this node includes the postage_stamp knob.")
+    postageStamp_knob.setTooltip(
+        "Enable the postage stamp thumbnail in this node.\nYou're seeing this because the class of this node includes the postage_stamp knob."
+    )
     postageStamp_knob.setFlag(nuke.STARTLINE)
     postageStamp_knob.setVisible("postage_stamp" in n.knobs() and nodeType(n) == "2D")
 
@@ -2063,9 +2065,9 @@ def backdropTags(node=None):
             label = re.sub("[\s]+", " ", label)
             label = re.sub("\.$", "", label)
             label = label.strip()
-            
+
             tags[label] = b
-                
+
     return tags
 
 
@@ -2669,8 +2671,8 @@ def renameTag(ns=""):
                 tags_knob.setValue(", ".join(merged_tags))
                 i += 1
             continue
-        if i > 0:
-            nuke.message("Renamed the specified tag on {} nodes.".format(str(i)))
+        # if i > 0:
+        #     nuke.message("Renamed the specified tag on {} nodes.".format(str(i)))
     return
 
 

--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -195,7 +195,7 @@ def wiredTagsAndBackdrops(n, updateSimilar=False):
         if not a:
             return
         a_tags = a["tags"].value().strip().strip(",")
-        a_bd = backdropTags(a)
+        a_bd = list(backdropTags(a).keys())
         an = n.knob("anchor").value()
         if updateSimilar:
             ns = [i for i in allWireds() if i.knob("anchor").value() == an]
@@ -1569,7 +1569,7 @@ class AnchorSelector(QtWidgets.QDialog):
                 # Remove leading/trailing spaces and separate by commas (with or without spaces)
                 tags = re.split(" *, *", tags_value.strip())
                 # backdrop_tags = ["$b$"+x for x in backdropTags(ni)]
-                backdrop_tags = backdropTags(ni)
+                backdrop_tags = list(backdropTags(ni))
                 for t in backdrop_tags:
                     if t not in self._backdrop_item_count:
                         self._backdrop_item_count[t] = 0
@@ -2049,7 +2049,7 @@ def getDefaultTitle(node=None):
 def backdropTags(node=None):
     """Returns the list of words belonging to the backdrop/s label/s"""
     backdrops = findBackdrops(node)
-    tags = []
+    tags = dict()
     for b in backdrops:
         if b.knob("visible_for_stamps"):
             if not b["visible_for_stamps"].value():
@@ -2063,7 +2063,9 @@ def backdropTags(node=None):
             label = re.sub("[\s]+", " ", label)
             label = re.sub("\.$", "", label)
             label = label.strip()
-            tags.append(label)
+            if not label in tags.keys():
+                tags[label] = b
+                
     return tags
 
 

--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -1,51 +1,72 @@
-#------------------------------------------------------
+# ------------------------------------------------------
 # Stamps by Adrian Pueyo and Alexey Kuchinski
 # Smart node connection system for Nuke
 # adrianpueyo.com, 2018-2021
-version= "v1.1"
-date = "May 18 2021"
-#-----------------------------------------------------
+# modified by Lukas Schwabe and Lukas Fabian, 2023
+
+import os
+import re
+import sys
+from functools import partial
+
+import labelConnectorForStamps
+import nuke
+
+version = "v2.0"
+date = "Nov 2023"
+# -----------------------------------------------------
 
 # Constants
-STAMP_DEFAULTS = { "note_font_size":20, "hide_input":0 }
-ANCHOR_DEFAULTS = { "tile_color" : int('%02x%02x%02x%02x' % (255,255,255,1),16),
-        "autolabel": 'nuke.thisNode().knob("title").value()',
-        "knobChanged":'stamps.anchorKnobChanged()',
-        "onCreate":'if nuke.GUI:\n    try:\n        import stamps; stamps.anchorOnCreate()\n    except:\n        pass'}
-WIRED_DEFAULTS = { "tile_color" : int('%02x%02x%02x%02x' % (1,0,0,1),16),
-        "autolabel": 'nuke.thisNode().knob("title").value()',
-        "knobChanged":'import stamps; stamps.wiredKnobChanged()'}
-DeepExceptionClasses = ["DeepToImage","DeepHoldout","DeepHoldout2"] # Nodes with "Deep" in their class that don't classify as Deep.
-NodeExceptionClasses = ["Viewer"] # Nodes that won't accept stamps
-ParticleExceptionClasses = ["ParticleToImage"] # Nodes with "Particle" in class and an input called "particles" that don't classify as particles.
-StampClasses = {"2D":"NoOp", "Deep":"DeepExpression"}
-AnchorClassesAlt = {"2D":"NoOp", "Deep":"DeepExpression"}
-StampClassesAlt = {"2D":"PostageStamp", "Deep":"DeepExpression", "3D":"LookupGeo", "Camera":"DummyCam", "Axis":"Axis", "Particle":"ParticleExpression"}
+STAMP_DEFAULTS = {"note_font_size": 20, "hide_input": 0}
+ANCHOR_DEFAULTS = {
+    "tile_color": int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16),
+    "autolabel": '"<center><font face=Verdana><b>"+nuke.thisNode().knob("title").value()+"</b>\\n<font size =1>("+("Hidden " if nuke.thisNode().knob("disable").value() else "")+"Anchor)</font></center>"',
+    "knobChanged": "stamps.anchorKnobChanged()",
+    "onCreate": "if nuke.GUI:\n    try:\n        import stamps; stamps.anchorOnCreate()\n    except Exception:\n        pass",
+    "onDestroy": "import stamps; stamps.anchorDestroy()",
+}
+WIRED_DEFAULTS = {
+    "tile_color": int("%02x%02x%02x%02x" % (1, 0, 0, 1), 16),
+    "autolabel": 'nuke.thisNode().knob("title").value()',
+    "knobChanged": "import stamps; stamps.wiredKnobChanged()",
+}
+# Nodes with "Deep" in their class that don't classify as Deep.
+DeepExceptionClasses = ["DeepToImage", "DeepHoldout", "DeepHoldout2"]
+NodeExceptionClasses = ["Viewer"]  # Nodes that won't accept stamps
+# Nodes with "Particle" in class and an input called "particles" that don't classify as particles.
+ParticleExceptionClasses = ["ParticleToImage"]
+StampClasses = {"2D": "NoOp", "Deep": "DeepExpression"}
+AnchorClassesAlt = {"2D": "NoOp", "Deep": "DeepExpression"}
+StampClassesAlt = {"2D": "NoOp", "Deep": "DeepExpression", "3D": "LookupGeo", "Camera": "DummyCam", "Axis": "Axis", "Particle": "ParticleExpression"}
+# modified for NoOp instead of PostageStamp
+# StampClassesAlt = {"2D": "PostageStamp", "Deep": "DeepExpression", "3D": "LookupGeo",
+#                    "Camera": "DummyCam", "Axis": "Axis", "Particle": "ParticleExpression"}
 InputIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 TitleIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 TagsIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 
-AnchorClassColors = {"Camera":int('%02x%02x%02x%02x' % (255,255,255,1),16),}
-WiredClassColors = {"Camera":int('%02x%02x%02x%02x' % (51,0,0,1),16),}
-STAMPS_HELP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated "+date
-VERSION_TOOLTIP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated "+date+"."
+AnchorClassColors = {
+    "Camera": int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16),
+}
+WiredClassColors = {
+    "Camera": int("%02x%02x%02x%02x" % (51, 0, 0, 1), 16),
+}
+STAMPS_HELP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated " + date
+VERSION_TOOLTIP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated " + date + "."
 STAMPS_SHORTCUT = "F8"
+
 KEEP_ORIGINAL_TAGS = True
 
-if 'Stamps_LastCreated' not in globals():
+USE_LABELCONNECTOR_UI = True  # switch for the new UI
+
+if "Stamps_LastCreated" not in globals():
     Stamps_LastCreated = None
 
-if 'Stamps_MenusLoaded' not in globals():
+if "Stamps_MenusLoaded" not in globals():
     Stamps_MenusLoaded = False
 
 Stamps_LockCallbacks = False
 
-import nuke
-import nukescripts
-import re
-from functools import partial
-import sys
-import os
 
 if sys.version_info[0] >= 3:
     unicode = str
@@ -53,10 +74,12 @@ if sys.version_info[0] >= 3:
 # PySide import switch
 try:
     if nuke.NUKE_VERSION_MAJOR < 11:
-        from PySide import QtCore, QtGui, QtGui as QtWidgets
+        from PySide import QtCore
+        from PySide import QtGui
+        from PySide import QtGui as QtWidgets
         from PySide.QtCore import Qt
     else:
-        from PySide2 import QtWidgets, QtGui, QtCore
+        from PySide2 import QtCore, QtGui, QtWidgets
         from PySide2.QtCore import Qt
 except ImportError:
     from Qt import QtCore, QtGui, QtWidgets
@@ -68,18 +91,34 @@ anchor_defaults.update(ANCHOR_DEFAULTS)
 
 wired_defaults = STAMP_DEFAULTS.copy()
 wired_defaults.update(WIRED_DEFAULTS)
+
+
+def getColorFromTags(tags=""):
+    """gets overriden by stamps_config if it exists"""
+    return None
+
+
+def setColorFromAnchor(Wired):
+    """gets overriden by stamps_config if it exists"""
+    pass
+
+
 try:
     from stamps_config import *
+
     if ANCHOR_STYLE:
         anchor_defaults.update(ANCHOR_STYLE)
     if STAMP_STYLE:
         wired_defaults.update(STAMP_STYLE)
-except:
+except Exception:
     pass
 
+
 #################################
-### FUNCTIONS INSIDE OF BUTTONS
+# FUNCTIONS INSIDE OF BUTTONS
 #################################
+
+
 def wiredShowAnchor():
     n = nuke.thisNode()
     a_name = n.knob("anchor").value()
@@ -88,23 +127,33 @@ def wiredShowAnchor():
     elif n.inputs():
         nuke.show(n.input(0))
 
+
 def wiredZoomAnchor():
     n = nuke.thisNode()
     a_name = n.knob("anchor").value()
     if nuke.exists(a_name):
         a = nuke.toNode(a_name)
-        #nuke.show(a)
-        nuke.zoom(nuke.zoom(),[a.xpos()+a.screenWidth()/2,a.ypos()+a.screenHeight()/2])
+        # nuke.show(a)
+        nuke.zoom(
+            nuke.zoom(),
+            [a.xpos() + a.screenWidth() / 2, a.ypos() + a.screenHeight() / 2],
+        )
     elif n.inputs():
         ni = n.input(0)
-        nuke.zoom(nuke.zoom(),[ni.xpos()+ni.screenWidth()/2,ni.ypos()+ni.screenHeight()/2])
+        nuke.zoom(
+            nuke.zoom(),
+            [ni.xpos() + ni.screenWidth() / 2, ni.ypos() + ni.screenHeight() / 2],
+        )
+
 
 def wiredZoomThis():
     n = nuke.thisNode()
-    nuke.zoom(nuke.zoom(),[n.xpos(),n.ypos()])
+    nuke.zoom(nuke.zoom(), [n.xpos(), n.ypos()])
 
-def wiredStyle(n, style = 0):
-    ''' Change the style of a wired stamp, based on some presets '''
+
+def wiredStyle(n, style=0):
+    """Change the style of a wired stamp, based on some presets"""
+    """
     if "note_font_size" in wired_defaults.keys():
         size = wired_defaults["note_font_size"]
     else:
@@ -118,19 +167,27 @@ def wiredStyle(n, style = 0):
         n["note_font_size"].setValue(size*2)
         n["note_font_color"].setValue(4278190335)
         n["note_font"].setValue(nf+" Bold")
+    """
+
+    if style == 0:  # DEFAULT
+        n["autolabel"].setValue('"<center><font face=Verdana><font size=3>"+nuke.thisNode().knob("title").value()')
+    elif style == 1:  # BROKEN
+        n["autolabel"].setValue('"<center><font face=Verdana><font size=6><b><font color=\\"red\\">"+nuke.thisNode().knob("title").value()')
+
 
 def wiredGetStyle(n):
-    ''' Check connection status of wired and set the style accordingly. '''
+    """Check connection status of wired and set the style accordingly."""
     if not isWired(n):
         return False
     if not n.inputs():
-        wiredStyle(n,1)
+        wiredStyle(n, 1)
     elif not isAnchor(n.input(0)):
-        wiredStyle(n,1)
+        wiredStyle(n, 1)
     elif n["anchor"].value() != n.input(0).name():
-        wiredStyle(n,1)
+        wiredStyle(n, 1)
     else:
-        wiredStyle(n,0)
+        wiredStyle(n, 0)
+
 
 def wiredTagsAndBackdrops(n, updateSimilar=False):
     try:
@@ -144,7 +201,7 @@ def wiredTagsAndBackdrops(n, updateSimilar=False):
             ns = [i for i in allWireds() if i.knob("anchor").value() == an]
         else:
             ns = [n]
-        
+
         for n in ns:
             try:
                 tags_knob = n.knob("tags")
@@ -157,22 +214,28 @@ def wiredTagsAndBackdrops(n, updateSimilar=False):
                 if len(a_bd) and a_bd != []:
                     bd_knob.setValue("<i>{}</i>".format(",".join(a_bd)))
                     bd_knob.setVisible(True)
-            except:
+            except Exception:
                 pass
-    except:
+    except Exception:
         try:
             [i.setVisible(False) for i in [tags_knob, bd_knob]]
-        except:
+        except Exception:
             pass
+
 
 def wiredKnobChanged():
     global Stamps_LockCallbacks
     k = nuke.thisKnob()
     kn = k.name()
-    if kn in ["xpos","ypos","reconnect_by_selection_this","reconnect_by_selection_similar"]:
+    if kn in [
+        "xpos",
+        "ypos",
+        "reconnect_by_selection_this",
+        "reconnect_by_selection_similar",
+    ]:
         return
     n = nuke.thisNode()
-    if Stamps_LockCallbacks == True:
+    if Stamps_LockCallbacks is True:
         return
     ni = n.inputs()
     if n.knob("toReconnect") and n.knob("toReconnect").value() and nuke.GUI:
@@ -182,19 +245,27 @@ def wiredKnobChanged():
                 for a in allAnchors():
                     if a.knob("title") and a["title"].value() == n["title"].value():
                         n.knob("auto_reconnect_by_title").setValue(False)
-                        nuke.thisNode().setInput(0,a)
+                        nuke.thisNode().setInput(0, a)
                         n["anchor"].setValue(a.name())
                         wiredStyle(n)
+                        try:
+                            setColorFromAnchor(nuke.thisNode())
+                        except Exception:
+                            pass
                         return
             try:
                 inp = n.knob("anchor").value()
                 a = nuke.toNode(inp)
                 if a.knob("title") and n.knob("title") and a["title"].value() == n["title"].value():
-                    nuke.thisNode().setInput(0,a)
+                    nuke.thisNode().setInput(0, a)
                     wiredStyle(n)
+                    try:
+                        setColorFromAnchor(nuke.thisNode())
+                    except Exception:
+                        pass
                 else:
-                    wiredStyle(n,1)
-            except:
+                    wiredStyle(n, 1)
+            except Exception:
                 wiredGetStyle(n)
         else:
             try:
@@ -206,96 +277,162 @@ def wiredKnobChanged():
                     inp = n.knob("anchor").value()
                     a = nuke.toNode(inp)
                     if a.knob("title") and n.knob("title") and a["title"].value() == n["title"].value():
-                        nuke.thisNode().setInput(0,a)
+                        nuke.thisNode().setInput(0, a)
+                        try:
+                            setColorFromAnchor(nuke.thisNode())
+                        except Exception:
+                            pass
                     else:
-                        wiredStyle(n,1)
-                        n.setInput(0,None)
-            except:
+                        wiredStyle(n, 1)
+                        n.setInput(0, None)
+            except Exception:
                 pass
         n.knob("toReconnect").setValue(False)
-    elif not ni:
-        if nodeType(n)=="Particle" and not nuke.env["nukex"]:
+    elif kn == "selected":  # First time it's this knob, it will activate the first if, then, ignore.
+        return
+    elif not ni and not kn == "inputChange":
+        if nodeType(n) == "Particle" and not nuke.env["nukex"]:
             return
-        wiredStyle(n,1)
+        wiredStyle(n, 1)
         return
-    elif kn == "selected": #First time it's this knob, it will activate the first if, then, ignore.
-        return
-    elif kn == "inputChange":
-        wiredGetStyle(n)
-    elif kn == "postage_stamp":
+    # elif kn == "inputChange":
+    #    wiredGetStyle(n)
+    elif kn == "postage_stamp" and "postageStamp_show" in n.knobs():
         n["postageStamp_show"].setVisible(True)
         n["postageStamp_show"].setValue(k.value())
     elif kn == "postageStamp_show":
         try:
             n["postage_stamp"].setValue(k.value())
-        except:
+        except Exception:
             n["postageStamp_show"].setVisible(False)
     elif kn == "title":
         kv = k.value()
         if titleIsLegal(kv):
             if nuke.ask("Do you want to update the linked stamps' title?"):
-                a = retitleAnchor(n) # Retitle anchor
-                retitleWired(a) # Retitle wired stamps of anchor a
+                a = retitleAnchor(n)  # Retitle anchor
+                retitleWired(a)  # Retitle wired stamps of anchor a
                 return
         else:
             nuke.message("Please set a valid title.")
         try:
             n["title"].setValue(n["prev_title"].value())
-        except:
+        except Exception:
             pass
     else:
         try:
             n.knob("toReconnect").setValue(False)
-            if ni:
+            if ni and kn != "anchor":
                 if isAnchor(n.input(0)):
                     if n.knob("title").value() == n.input(0).knob("title").value():
                         n.knob("anchor").setValue(n.input(0).name())
-                    elif nuke.ask("Do you want to change the anchor for the current stamp?"):
-                        n.knob("anchor").setValue(n.input(0).name())
-                        n.knob("title").setValue(n.input(0).knob("title").value())
-                        n.knob("prev_title").setValue(n.input(0).knob("title").value())
+                        setColorFromAnchor(nuke.thisNode())
+
+                    # the following case makes it impossible to swap stamps with the ctrl+shift+dragndrop workflow
+
+                    # elif nuke.ask("Do you want to change the anchor for the current stamp?"):
+                    #     n.knob("anchor").setValue(n.input(0).name())
+                    #     n.knob("title").setValue(n.input(0).knob("title").value())
+                    #     n.knob("prev_title").setValue(n.input(0).knob("title").value())
+
                     else:
-                        n.setInput(0,None)
+                        n.setInput(0, None)
                         try:
-                            n.setInput(0,nuke.toNode(n.knob("anchor").value()))
-                        except:
+                            n.setInput(0, nuke.toNode(n.knob("anchor").value()))
+                        except Exception:
                             pass
+
+                else:
+                    try:
+                        n.setInput(0, nuke.toNode(n.knob("anchor").value()))
+                    except Exception:
+                        pass
+            else:
+                try:
+                    n.setInput(0, nuke.toNode(n.knob("anchor").value()))
+                except Exception:
+                    pass
+
             wiredGetStyle(n)
-        except:
+        except Exception:
             pass
 
     if kn == "showPanel":
         wiredTagsAndBackdrops(n)
 
+
 def wiredOnCreate():
     n = nuke.thisNode()
     n.knob("toReconnect").setValue(1)
+
+    if n.Class() == "DeepExpression":
+        n.knob("chans0").setValue("none")
+        n.knob("chans1").setValue("none")
+
     for k in n.allKnobs():
-        if k.name() not in ['wired_tab','identifier','lockCallbacks','toReconnect','title','prev_title','tags','backdrops','anchor','line1','anchor_label','show_anchor','zoom_anchor','stamps_label','zoomNext','selectSimilar','space_1','reconnect_label','reconnect_this','reconnect_similar','reconnect_all','space_2','advanced_reconnection','reconnect_by_title_label','reconnect_by_title_this','reconnect_by_title_similar', 'reconnect_by_title_selected', 'reconnect_by_selection_label','reconnect_by_selection_this','reconnect_by_selection_similar','reconnect_by_selection_selected','auto_reconnect_by_title','advanced_reconnection','line2','buttonHelp','version','postageStamp_show']:
+        if k.name() not in [
+            "wired_tab",
+            "identifier",
+            "lockCallbacks",
+            "toReconnect",
+            "title",
+            "prev_title",
+            "tags",
+            "backdrops",
+            "anchor",
+            "line1",
+            "anchor_label",
+            "show_anchor",
+            "zoom_anchor",
+            "stamps_label",
+            "zoomNext",
+            "selectSimilar",
+            "space_1",
+            "reconnect_label",
+            "reconnect_this",
+            "reconnect_similar",
+            "reconnect_all",
+            "space_2",
+            "advanced_reconnection",
+            "reconnect_by_title_label",
+            "reconnect_by_title_this",
+            "reconnect_by_title_similar",
+            "reconnect_by_title_selected",
+            "reconnect_by_selection_label",
+            "reconnect_by_selection_this",
+            "reconnect_by_selection_similar",
+            "reconnect_by_selection_selected",
+            "auto_reconnect_by_title",
+            "advanced_reconnection",
+            "line2",
+            "buttonHelp",
+            "version",
+            "postageStamp_show",
+        ]:
             k.setFlag(0x0000000000000400)
+
 
 def anchorKnobChanged():
     k = nuke.thisKnob()
     kn = k.name()
-    if kn in ["xpos","ypos"]:
+    if kn in ["xpos", "ypos"]:
         return
     n = nuke.thisNode()
     if kn == "title":
         kv = k.value()
         if titleIsLegal(kv):
             if nuke.ask("Do you want to update the linked stamps' title?"):
-                retitleWired(n) # Retitle wired stamps of anchor a
+                retitleWired(n)  # Retitle wired stamps of anchor a
                 return
         else:
             nuke.message("Please set a valid title.")
         try:
             n["title"].setValue(n["prev_title"].value())
-        except:
+        except Exception:
             pass
     elif kn == "name":
         try:
             nn = anchor["prev_name"].value()
-        except:
+        except Exception:
             nn = anchor.name()
         children = anchorWireds(n)
         for i in children:
@@ -307,26 +444,108 @@ def anchorKnobChanged():
                 wiredTagsAndBackdrops(ni, updateSimilar=True)
                 return
 
+    elif kn == "tile_color":
+        children = anchorWireds(n)
+        for child in children:
+            child.knob("tile_color").setValue(n.knob("tile_color").value())
+
+    elif kn == "disable":
+        if n.knob("disable_save"):
+            n.knob("disable_save").setValue(n.knob("disable").value())
+
+
+def updateAnchor(anchor):
+    if not anchor.knob("onDestroy").value():
+        anchor.knob("onDestroy").setValue(ANCHOR_DEFAULTS["onDestroy"])  # temp to set onDestroy Callback on old Anchors
+
+    if not anchor.knob("line3"):
+        anchor.addKnob(nuke.Text_Knob("line3", "", ""))  # Line
+
+    if not anchor.knob("disable"):
+        disable_knob = nuke.Boolean_Knob("disable", "Hide in Stamps UI (D)", False)
+        disable_knob.setFlag(nuke.STARTLINE)
+        anchor.addKnob(disable_knob)
+
+    if not anchor.knob("disable_save"):
+        disable_knob_save_state = nuke.Boolean_Knob("disable_save", "Save Disable State", False)
+        disable_knob_save_state.setFlag(nuke.STARTLINE)
+        disable_knob_save_state.setFlag(0x0000000000000400)
+        anchor.addKnob(disable_knob_save_state)
+
+    return anchor
+
+
 def anchorOnCreate():
     n = nuke.thisNode()
+
+    n = updateAnchor(n)
+
+    # The Deepexpression node is a special case to preserve the disable status, as it is a default knob. we need to override again
+    if n.Class() == "DeepExpression":
+        disable_value = n.knob("disable_save").value()
+
+        n.knob("disable").setValue(False)
+        n.knob("disable").setName("obsolete_disable")
+
+        disable_knob = nuke.Boolean_Knob("disable", "Hide in Stamps UI (D)", False)
+        disable_knob.setFlag(nuke.STARTLINE)
+        n.addKnob(disable_knob)
+        disable_knob.setValue(disable_value)
+
+        n.knob("chans0").setValue("none")
+        n.knob("chans1").setValue("none")
+
     for k in n.allKnobs():
-        if k.name() not in ['anchor_tab','identifier','title','prev_title','prev_name','showing','tags','stamps_label','selectStamps','reconnectStamps','zoomNext','createStamp','buttonHelp','line1','line2','version']:
+        if k.name() not in [
+            "anchor_tab",
+            "identifier",
+            "title",
+            "prev_title",
+            "prev_name",
+            "showing",
+            "tags",
+            "stamps_label",
+            "selectStamps",
+            "reconnectStamps",
+            "zoomNext",
+            "createStamp",
+            "buttonHelp",
+            "line1",
+            "line2",
+            "line3",
+            "version",
+            "disable",
+        ]:
             k.setFlag(0x0000000000000400)
     try:
         nn = n["prev_name"].value()
-    except:
+    except Exception:
         nn = n.name()
     children = anchorWireds(n)
     for i in children:
+        # in case of an Undo that restores an Anchor, the Stamps input isn't connected yet. Doing it here sets the style correctly.
+        i.setInput(0, n)
         i.knob("anchor").setValue(nn)
     n["prev_name"].setValue(n.name())
     return
 
-def retitleAnchor(ref = ""):
-    '''
+
+def anchorDestroy():
+    if nuke.GUI:
+        try:
+            n = nuke.thisNode()
+            children = anchorWireds(n)
+            for i in children:
+                i.knob("anchor").setValue("No Anchor")
+        except ValueError:
+            pass
+
+
+def retitleAnchor(ref=""):
+    """
     Retitle Anchor of current wired stamp to match its title.
     returns: anchor node
-    ''' 
+    """
     if ref == "":
         ref = nuke.thisNode()
     try:
@@ -335,17 +554,18 @@ def retitleAnchor(ref = ""):
             ref_title = ref_title.strip()
         ref_anchor = ref["anchor"].value()
         na = nuke.toNode(ref_anchor)
-        for kn in ["title","prev_title"]:
+        for kn in ["title", "prev_title"]:
             na[kn].setValue(ref_title)
         ref["prev_title"].setValue(ref_title)
         return na
-    except:
+    except Exception:
         return None
 
-def retitleWired(anchor = ""):
-    '''
+
+def retitleWired(anchor=""):
+    """
     Retitle wired stamps connected to supplied anchor
-    '''
+    """
     if anchor == "":
         return
     try:
@@ -356,47 +576,50 @@ def retitleWired(anchor = ""):
                 nw["title"].setValue(anchor_title)
                 nw["prev_title"].setValue(anchor_title)
         return True
-    except:
+    except Exception:
         pass
 
-def wiredSelectSimilar(anchor_name = ""):
-    if anchor_name=="":
+
+def wiredSelectSimilar(anchor_name=""):
+    if anchor_name == "":
         anchor_name = nuke.thisNode().knob("anchor").value()
     for i in allWireds():
         if i.knob("anchor").value() == anchor_name:
             i.setSelected(True)
 
+
 def wiredReconnect(n=""):
-    succeeded=True
-    if n=="":
+    succeeded = True
+    if n == "":
         n = nuke.thisNode()
-    try:
-        anchor = nuke.toNode(n.knob("anchor").value())
-        if not anchor:
-            succeeded = False
-        n.setInput(0,anchor)
-    except:
-        succeeded = False
+
+    anchor = nuke.toNode(n.knob("anchor").value())
+
+    succeeded = n.setInput(0, anchor)
+    succeeded = False
+
     try:
         wiredGetStyle(n)
-    except:
+    except Exception:
         pass
     return succeeded
 
-def wiredReconnectSimilar(anchor_name = ""):
-    if anchor_name=="":
+
+def wiredReconnectSimilar(anchor_name=""):
+    if anchor_name == "":
         anchor_name = nuke.thisNode().knob("anchor").value()
     for i in nuke.allNodes():
         if isWired(i) and i.knob("anchor").value() == anchor_name:
             reconnectErrors = 0
             try:
                 i.knob("reconnect_this").execute()
-            except:
+            except Exception:
                 reconnectErrors += 1
             finally:
                 if reconnectErrors > 0:
                     nuke.message("Couldn't reconnect {} nodes".format(str(reconnectErrors)))
         wiredGetStyle(i)
+
 
 def wiredReconnectAll():
     for i in nuke.allNodes():
@@ -404,28 +627,29 @@ def wiredReconnectAll():
             reconnectErrors = 0
             try:
                 i.knob("reconnect_this").execute()
-            except:
+            except Exception:
                 reconnectErrors += 1
             finally:
                 if reconnectErrors > 0:
                     nuke.message("Couldn't reconnect {} nodes".format(str(reconnectErrors)))
 
+
 def wiredReconnectByTitle(title=""):
-    #1. Find matching nodes.
+    # 1. Find matching nodes.
     n = nuke.thisNode()
-    if title=="":
+    if title == "":
         title = n.knob("title").value()
     matches = []
     for i in nuke.allNodes():
         if isAnchor(i) and i.knob("title").value() == title:
             matches.append(i)
 
-    #2. Do what's necessary
+    # 2. Do what's necessary
     num_matches = len(matches)
-    if num_matches == 1: # One match -> Connect
+    if num_matches == 1:  # One match -> Connect
         anchor = matches[0]
         n["anchor"].setValue(anchor.name())
-        n.setInput(0,anchor)
+        n.setInput(0, anchor)
     elif num_matches > 1:
         # More than one match...
         ns = nuke.selectedNodes()
@@ -433,7 +657,7 @@ def wiredReconnectByTitle(title=""):
             # Exactly one anchor selected and title matches -> connect
             if ns[0].knob("title").value() == title:
                 n["anchor"].setValue(ns[0].name())
-                n.setInput(0,ns[0])
+                n.setInput(0, ns[0])
                 n.knob("reconnect_this").execute()
         else:
             # Selection not matching -> Message asking to select a specific anchor.
@@ -441,17 +665,18 @@ def wiredReconnectByTitle(title=""):
     elif num_matches == 0:
         nuke.message("No Anchor Stamps with title '{}' found in the script.".format(title))
 
+
 def wiredReconnectByTitleSimilar(title=""):
-    #1. Find matching anchors.
+    # 1. Find matching anchors.
     n = nuke.thisNode()
-    if title=="":
+    if title == "":
         title = n.knob("title").value()
     matches = []
     for i in allAnchors():
         if i.knob("title").value() == title:
             matches.append(i)
 
-    #2. Do what's necessary
+    # 2. Do what's necessary
     num_matches = len(matches)
     if num_matches == 0:
         # No matches -> abort
@@ -461,12 +686,12 @@ def wiredReconnectByTitleSimilar(title=""):
     anchor_name = n.knob("anchor").value()
     siblings = [i for i in nuke.allNodes() if isWired(i) and i.knob("anchor").value() == anchor_name]
 
-    if num_matches == 1: # One match -> Connect
+    if num_matches == 1:  # One match -> Connect
         anchor = matches[0]
         for s in siblings:
             s["anchor"].setValue(anchor.name())
-            s.setInput(0,anchor)
-            wiredStyle(s,0)
+            s.setInput(0, anchor)
+            wiredStyle(s, 0)
             s.knob("reconnect_this").execute()
     elif num_matches > 1:
         # More than one match...
@@ -476,15 +701,16 @@ def wiredReconnectByTitleSimilar(title=""):
             if ns[0].knob("title").value() == title:
                 for s in siblings:
                     s["anchor"].setValue(ns[0].name())
-                    s.setInput(0,ns[0])
-                    wiredStyle(s,0)
+                    s.setInput(0, ns[0])
+                    wiredStyle(s, 0)
                     s.knob("reconnect_this").execute()
         else:
             # Selection not matching -> Message asking to select a specific anchor.
             nuke.message("More than one Anchor Stamp found with the same title. Please select the one you like in the Node Graph and click this button again.")
 
+
 def wiredReconnectByTitleSelected():
-    #1. Find matching anchors.
+    # 1. Find matching anchors.
     ns = nuke.selectedNodes()
     ns = [i for i in ns if isWired(i)]
 
@@ -495,14 +721,15 @@ def wiredReconnectByTitleSelected():
             if i.knob("title").value() == title:
                 matches.append(i)
 
-        #2. Do what's necessary only for the one match cases
-        anchor_name = n.knob("anchor").value()
-        if len(matches) == 1: # One match -> Connect
+        # 2. Do what's necessary only for the one match cases
+        # anchor_name = n.knob("anchor").value()
+        if len(matches) == 1:  # One match -> Connect
             anchor = matches[0]
             n["anchor"].setValue(anchor.name())
-            n.setInput(0,anchor)
-            wiredStyle(n,0)
+            n.setInput(0, anchor)
+            wiredStyle(n, 0)
             n.knob("reconnect_this").execute()
+
 
 def wiredReconnectBySelection():
     global Stamps_LockCallbacks
@@ -511,7 +738,7 @@ def wiredReconnectBySelection():
 
     if not len(ns):
         nuke.message("Please select an Anchor Stamp first.")
-    elif len(ns)>1:
+    elif len(ns) > 1:
         nuke.message("Multiple nodes selected, please select only one Anchor Stamp.")
     else:
         if not isAnchor(ns[0]):
@@ -520,10 +747,11 @@ def wiredReconnectBySelection():
             Stamps_LockCallbacks = True
             n["anchor"].setValue(ns[0].name())
             n["title"].setValue(ns[0]["title"].value())
-            n.setInput(0,ns[0])
+            n.setInput(0, ns[0])
             wiredGetStyle(n)
             Stamps_LockCallbacks = False
             n.knob("reconnect_this").execute()
+
 
 def wiredReconnectBySelectionSimilar():
     global Stamps_LockCallbacks
@@ -532,7 +760,7 @@ def wiredReconnectBySelectionSimilar():
 
     if not len(ns):
         nuke.message("Please select an Anchor Stamp first.")
-    elif len(ns)>1:
+    elif len(ns) > 1:
         nuke.message("Multiple nodes selected, please select only one Anchor Stamp.")
     elif not isAnchor(ns[0]):
         nuke.message("Please select an Anchor Stamp.")
@@ -543,14 +771,15 @@ def wiredReconnectBySelectionSimilar():
             Stamps_LockCallbacks = True
             s["anchor"].setValue(ns[0].name())
             s["title"].setValue(ns[0]["title"].value())
-            s.setInput(0,ns[0])
-            wiredStyle(s,0)
+            s.setInput(0, ns[0])
+            wiredStyle(s, 0)
             Stamps_LockCallbacks = False
             s.knob("reconnect_this").execute()
 
+
 def wiredReconnectBySelectionSelected():
     global Stamps_LockCallbacks
-    n = nuke.thisNode()
+    # n = nuke.thisNode()
     ns = nuke.selectedNodes()
 
     if not len(ns):
@@ -578,28 +807,30 @@ def wiredReconnectBySelectionSelected():
         Stamps_LockCallbacks = True
         s["anchor"].setValue(anchor.name())
         s["title"].setValue(anchor["title"].value())
-        s.setInput(0,anchor)
-        wiredStyle(s,0)
+        s.setInput(0, anchor)
+        wiredStyle(s, 0)
         Stamps_LockCallbacks = False
         s.knob("reconnect_this").execute()
 
-def anchorReconnectWired(anchor = ""):
-    if anchor=="":
+
+def anchorReconnectWired(anchor=""):
+    if anchor == "":
         anchor = nuke.thisNode()
     anchor_name = anchor.name()
     for i in allWireds():
         if i.knob("anchor").value() == anchor_name:
             reconnectErrors = 0
             try:
-                i.setInput(0,anchor)
-            except:
+                i.setInput(0, anchor)
+            except Exception:
                 reconnectErrors += 1
             finally:
                 if reconnectErrors > 0:
                     nuke.message("Couldn't reconnect {} nodes".format(str(reconnectErrors)))
 
-def wiredZoomNext(anchor_name = ""):
-    if anchor_name=="":
+
+def wiredZoomNext(anchor_name="", no_error=False):
+    if anchor_name == "":
         anchor_name = nuke.thisNode().knob("anchor").value()
     anchor = nuke.toNode(anchor_name)
     showing_knob = anchor.knob("showing")
@@ -608,42 +839,54 @@ def wiredZoomNext(anchor_name = ""):
     for ni in allWireds():
         if ni.knob("anchor").value() == anchor_name:
             if i == showing_value:
-                nuke.zoom(1.5,[ni.xpos()+ni.screenWidth()/2,ni.ypos()+ni.screenHeight()/2])
-                showing_knob.setValue(i+1)
+                nuke.zoom(
+                    1.5,
+                    [
+                        ni.xpos() + ni.screenWidth() / 2,
+                        ni.ypos() + ni.screenHeight() / 2,
+                    ],
+                )
+                showing_knob.setValue(i + 1)
                 return
-            i+=1
+            i += 1
     showing_knob.setValue(0)
-    nuke.message("Couldn't find any more similar wired stamps.")
+    if not no_error:
+        nuke.message("Couldn't find any more similar wired stamps.")
 
-def anchorSelectWireds(anchor = ""):
+
+def anchorSelectWireds(anchor=""):
     if anchor == "":
         try:
             anchor = nuke.selectedNode()
-        except:
+        except Exception:
             pass
     if isAnchor(anchor):
         anchor.setSelected(False)
         wiredSelectSimilar(anchor.name())
 
-def anchorWireds(anchor = ""):
-    ''' Returns a list of the children stamps to the anchor with the specified name '''
+
+def anchorWireds(anchor=""):
+    """Returns a list of the children stamps to the anchor with the specified name"""
     if anchor == "":
         try:
             anchor = nuke.selectedNode()
-        except:
+        except Exception:
             pass
     if isAnchor(anchor):
         try:
             nn = anchor["prev_name"].value()
-        except:
+        except Exception:
             nn = anchor.name()
+        # "No Anchor" is for stamps that have been disconnected from their anchor
         children = [i for i in allWireds() if i.knob("anchor").value() == nn]
         return children
 
-wiredOnCreate_code = """if nuke.GUI:
+
+wiredOnCreate_code = """
+if nuke.GUI:
     try:
         import stamps; stamps.wiredOnCreate()
-    except:
+    except Exception:
         pass
 """
 
@@ -654,119 +897,167 @@ try:
         if a.knob("identifier").value() == "anchor" and a.knob("title").value() == nt:
             n.setInput(0,a)
             break
-except:
+except Exception:
     nuke.message("Unable to reconnect.")
 """
 
 wiredReconnect_code = """n = nuke.thisNode()
 try:
     n.setInput(0,nuke.toNode(n.knob("anchor").value()))
-except:
+except Exception:
     nuke.message("Unable to reconnect.")
 try:
     import stamps
     stamps.wiredGetStyle(n)
-except:
+except Exception:
     pass
 """
 
 #################################
-### STAMP, ANCHOR, WIRED
+# STAMP, ANCHOR, WIRED
 #################################
 
-def anchor(title = "", tags = "", input_node = "", node_type = "2D"):
-    ''' Anchor Stamp '''
+
+def anchor(title="", tags="", input_node="", node_type="2D"):
+    """Anchor Stamp"""
     try:
         n = nuke.createNode(AnchorClassesAlt[node_type])
-    except:
+    except Exception:
         try:
             n = nuke.createNode(StampClasses[node_type])
-        except:
+        except Exception:
             n = nuke.createNode("NoOp")
-    name = getAvailableName("Anchor",rand=True)
-    n["name"].setValue(name)
+    # name = getAvailableName("Anchor",rand=True)        #commented out to try performance tweak
+    name = getRandomName("Anchor")
+    n.setName(name)
+    # read back the name again, in case n.setName() had to change the node name to make it unique
+    name = n.name()
+
     # Set default knob values
-    for i,j in anchor_defaults.items():
+    for i, j in anchor_defaults.items():
         try:
             n.knob(i).setValue(j)
-        except:
+        except Exception:
             pass
 
     if node_type in AnchorClassColors:
         try:
             n["tile_color"].setValue(AnchorClassColors[node_type])
-        except:
+        except Exception:
             pass
 
     for k in n.allKnobs():
         k.setFlag(0x0000000000000400)
 
     # Main knobs
-    anchorTab_knob = nuke.Tab_Knob('anchor_tab','Anchor Stamp')
-    identifier_knob = nuke.Text_Knob('identifier','identifier', 'anchor')
+    anchorTab_knob = nuke.Tab_Knob("anchor_tab", "Anchor Stamp")
+    identifier_knob = nuke.Text_Knob("identifier", "identifier", "anchor")
     identifier_knob.setVisible(False)
-    title_knob = nuke.String_Knob('title','Title:', title)
-    title_knob.setTooltip("Displayed name on the Node Graph for this Stamp and its Anchor.\nIMPORTANT: This is only for display purposes, and is different from the real/internal name of the Stamps.")
-    prev_title_knob = nuke.Text_Knob('prev_title','', title)
+    title_knob = nuke.String_Knob("title", "Title:", title)
+    title_knob.setTooltip(
+        "Displayed name on the Node Graph for this Stamp and its Anchor.\nIMPORTANT: This is only for display purposes, and is different from the real/internal name of the Stamps."
+    )
+    prev_title_knob = nuke.Text_Knob("prev_title", "", title)
     prev_title_knob.setVisible(False)
-    prev_name_knob = nuke.Text_Knob('prev_name','', name)
+    prev_name_knob = nuke.Text_Knob("prev_name", "", name)
     prev_name_knob.setVisible(False)
-    showing_knob = nuke.Int_Knob('showing','', 0)
+    showing_knob = nuke.Int_Knob("showing", "", 0)
     showing_knob.setVisible(False)
-    tags_knob = nuke.String_Knob('tags','Tags', tags)
-    tags_knob.setTooltip("Comma-separated tags you can define for each Anchor, that will help you find it when invoking the Stamp Selector by pressing the Stamps shortkey with nothing selected.")
+    tags_knob = nuke.String_Knob("tags", "Tags", tags)
+    tags_knob.setTooltip(
+        "Comma-separated tags you can define for each Anchor, that will help you find it when invoking the Stamp Selector by pressing the Stamps shortkey with nothing selected."
+    )
+
     for k in [anchorTab_knob, identifier_knob, title_knob, prev_title_knob, prev_name_knob, showing_knob, tags_knob]:
         n.addKnob(k)
 
-    n.addKnob(nuke.Text_Knob("line1", "", "")) # Line
+    n.addKnob(nuke.Text_Knob("line1", "", ""))  # Line
 
-    stampsLabel_knob = nuke.Text_Knob('stamps_label','Stamps:', " ")
+    stampsLabel_knob = nuke.Text_Knob("stamps_label", "Stamps:", " ")
     stampsLabel_knob.setFlag(nuke.STARTLINE)
 
     # Buttons
-    buttonSelectStamps = nuke.PyScript_Knob("selectStamps","select","stamps.wiredSelectSimilar(nuke.thisNode().name())")
+    buttonSelectStamps = nuke.PyScript_Knob("selectStamps", "select", "stamps.wiredSelectSimilar(nuke.thisNode().name())")
     buttonSelectStamps.setTooltip("Select all of this Anchor's Stamps.")
-    buttonReconnectStamps = nuke.PyScript_Knob("reconnectStamps","reconnect","stamps.anchorReconnectWired()")
+    buttonReconnectStamps = nuke.PyScript_Knob("reconnectStamps", "reconnect", "stamps.anchorReconnectWired()")
     buttonSelectStamps.setTooltip("Reconnect all of this Anchor's Stamps.")
-    buttonZoomNext = nuke.PyScript_Knob("zoomNext","zoom next","stamps.wiredZoomNext(nuke.thisNode().name())")
+    buttonZoomNext = nuke.PyScript_Knob("zoomNext", "zoom next", "stamps.wiredZoomNext(nuke.thisNode().name())")
     buttonZoomNext.setTooltip("Navigate to this Anchor's next Stamp on the Node Graph.")
-    buttonCreateStamp = nuke.PyScript_Knob("createStamp","new","stamps.stampCreateWired(nuke.thisNode())")
+    buttonCreateStamp = nuke.PyScript_Knob("createStamp", "new", "stamps.stampCreateWired(nuke.thisNode())")
     buttonCreateStamp.setTooltip("Create a new Stamp for this Anchor.")
 
-    for k in [stampsLabel_knob, buttonCreateStamp, buttonSelectStamps, buttonReconnectStamps, buttonZoomNext]:
+    for k in [
+        stampsLabel_knob,
+        buttonCreateStamp,
+        buttonSelectStamps,
+        buttonReconnectStamps,
+        buttonZoomNext,
+    ]:
         n.addKnob(k)
 
     # Version (for future update checks)
-    n.addKnob(nuke.Text_Knob("line2", "", "")) # Line
-    buttonHelp = nuke.PyScript_Knob("buttonHelp","Help","stamps.showHelp()")
-    version_knob = nuke.Text_Knob('version',' ','<a href="http://www.nukepedia.com/gizmos/other/stamps" style="color:#666;text-decoration: none;"><span style="color:#666"> <big>Stamps {}</big></b></a>'.format(version))
+    n.addKnob(nuke.Text_Knob("line2", "", ""))  # Line
+    buttonHelp = nuke.PyScript_Knob("buttonHelp", "Help", "stamps.showHelp()")
+    version_knob = nuke.Text_Knob(
+        "version",
+        " ",
+        '<a href="http://www.nukepedia.com/gizmos/other/stamps" style="color:#666;text-decoration: none;"><span style="color:#666"> <big>Stamps {}</big></b></a>'.format(
+            version
+        ),
+    )
     version_knob.setTooltip(VERSION_TOOLTIP)
     version_knob.clearFlag(nuke.STARTLINE)
     for k in [buttonHelp, version_knob]:
         n.addKnob(k)
     n["help"].setValue(STAMPS_HELP)
 
+    n.addKnob(nuke.Text_Knob("line3", "", ""))  # Line
+
+    # for DeepExpression, there is a disable already. Let's rename, so we can add our own.
+    if n.knob("disable"):
+        disable_knob = n.knob("disable").setName("obsolete_disable")
+
+    disable_knob = nuke.Boolean_Knob("disable", "Hide in Stamps UI (D)", False)
+    disable_knob.setFlag(nuke.STARTLINE)
+    n.addKnob(disable_knob)
+
+    # for some reason on DeepExpressions we can't recover the disable state, so we need to save it somewhere else
+    disable_knob_save_state = nuke.Boolean_Knob("disable_save", "Save Disable State", False)
+    disable_knob_save_state.setFlag(nuke.STARTLINE)
+    disable_knob_save_state.setFlag(0x0000000000000400)
+    n.addKnob(disable_knob_save_state)
+
+    tagsForColor = n["tags"].getValue()
+    tc = getColorFromTags(tags=tagsForColor)
+    if tc:
+        n["tile_color"].setValue(tc)
+        tc = None
+
+    n.setYpos(n.ypos() + 30)
+
     return n
 
+
 def wired(anchor):
-    ''' Wired Stamp '''
+    """Wired Stamp"""
     global Stamps_LastCreated
     Stamps_LastCreated = anchor.name()
 
     node_type = nodeType(realInput(anchor))
     try:
         n = nuke.createNode(StampClassesAlt[node_type])
-    except:
+    except Exception:
         try:
             n = nuke.createNode(StampClasses[node_type])
-        except:
+        except Exception:
             n = nuke.createNode("NoOp")
-    n["name"].setValue(getAvailableName("Stamp"))
+    # n["name"].setValue(getAvailableName("Stamp"))     #commented out to try performance tweak in next line
+    n.setName("Stamp")
     # Set default knob values
-    for i,j in wired_defaults.items():
+    for i, j in wired_defaults.items():
         try:
             n[i].setValue(j)
-        except:
+        except Exception:
             pass
 
     for k in n.allKnobs():
@@ -777,57 +1068,59 @@ def wired(anchor):
     n["onCreate"].setValue(wiredOnCreate_code)
 
     # Inner functionality knobs
-    wiredTab_knob = nuke.Tab_Knob('wired_tab','Wired Stamp')
-    identifier_knob = nuke.Text_Knob('identifier','identifier', 'wired')
+    wiredTab_knob = nuke.Tab_Knob("wired_tab", "Wired Stamp")
+    identifier_knob = nuke.Text_Knob("identifier", "identifier", "wired")
     identifier_knob.setVisible(False)
-    lock_knob = nuke.Int_Knob('lockCallbacks','',0) #Lock callbacks...
+    lock_knob = nuke.Int_Knob("lockCallbacks", "", 0)  # Lock callbacks...
     lock_knob.setVisible(False)
     toReconnect_knob = nuke.Boolean_Knob("toReconnect")
     toReconnect_knob.setVisible(False)
-    title_knob = nuke.String_Knob('title','Title:', anchor["title"].value())
-    title_knob.setTooltip("Displayed name on the Node Graph for this Stamp and its Anchor.\nIMPORTANT: This is only for display purposes, and is different from the real/internal name of the Stamps.")
-    prev_title_knob = nuke.Text_Knob('prev_title','', anchor["title"].value())
+    title_knob = nuke.String_Knob("title", "Title:", anchor["title"].value())
+    title_knob.setTooltip(
+        "Displayed name on the Node Graph for this Stamp and its Anchor.\nIMPORTANT: This is only for display purposes, and is different from the real/internal name of the Stamps."
+    )
+    prev_title_knob = nuke.Text_Knob("prev_title", "", anchor["title"].value())
     prev_title_knob.setVisible(False)
-    tags_knob = nuke.Text_Knob('tags','Tags:', " ")
-    tags_knob.setTooltip("Tags of this stamp's Anchor, for information purpose only.\nClick \"show anchor\" to change them.")
-    backdrops_knob = nuke.Text_Knob('backdrops','Backdrops:', " ")
+    tags_knob = nuke.Text_Knob("tags", "Tags:", " ")
+    tags_knob.setTooltip('Tags of this stamp\'s Anchor, for information purpose only.\nClick "show anchor" to change them.')
+    backdrops_knob = nuke.Text_Knob("backdrops", "Backdrops:", " ")
     backdrops_knob.setTooltip("Labels of backdrop nodes which contain this stamp's Anchor.")
-    postageStamp_knob = nuke.Boolean_Knob("postageStamp_show","postage stamp")
+    postageStamp_knob = nuke.Boolean_Knob("postageStamp_show", "postage stamp")
     postageStamp_knob.setTooltip("Enable the postage stamp thumbnail in this node.\nYou're seeing this because the class of this node includes the postage_stamp knob.")
     postageStamp_knob.setFlag(nuke.STARTLINE)
     postageStamp_knob.setVisible("postage_stamp" in n.knobs() and nodeType(n) == "2D")
 
-    anchor_knob = nuke.String_Knob('anchor','Anchor', anchor.name()) # This goes in the advanced part
+    anchor_knob = nuke.String_Knob("anchor", "Anchor", anchor.name())  # This goes in the advanced part
 
     for k in [wiredTab_knob, identifier_knob, lock_knob, toReconnect_knob, title_knob, prev_title_knob, tags_knob, backdrops_knob]:
         n.addKnob(k)
 
-    wiredTab_knob.setFlag(0) # Open the tab
+    wiredTab_knob.setFlag(0)  # Open the tab
 
-    n.addKnob(nuke.Text_Knob("line1", "", "")) # Line
+    n.addKnob(nuke.Text_Knob("line1", "", ""))  # Line
     n.addKnob(postageStamp_knob)
 
-    ### Buttons
+    # Buttons
 
     # Anchor
-    anchorLabel_knob = nuke.Text_Knob('anchor_label','Anchor:', " ")
+    anchorLabel_knob = nuke.Text_Knob("anchor_label", "Anchor:", " ")
     anchorLabel_knob.setFlag(nuke.STARTLINE)
-    buttonShowAnchor = nuke.PyScript_Knob("show_anchor"," show anchor ","stamps.wiredShowAnchor()")
+    buttonShowAnchor = nuke.PyScript_Knob("show_anchor", " show anchor ", "stamps.wiredShowAnchor()")
     buttonShowAnchor.setTooltip("Show the properties panel for this Stamp's Anchor.")
     buttonShowAnchor.clearFlag(nuke.STARTLINE)
-    buttonZoomAnchor = nuke.PyScript_Knob("zoom_anchor","zoom anchor","stamps.wiredZoomAnchor()")
+    buttonZoomAnchor = nuke.PyScript_Knob("zoom_anchor", "zoom anchor", "stamps.wiredZoomAnchor()")
     buttonZoomAnchor.setTooltip("Navigate to this Stamp's Anchor on the Node Graph.")
 
     for k in [anchorLabel_knob, buttonShowAnchor, buttonZoomAnchor]:
         n.addKnob(k)
 
     # Stamps
-    stampsLabel_knob = nuke.Text_Knob('stamps_label','Stamps:', " ")
+    stampsLabel_knob = nuke.Text_Knob("stamps_label", "Stamps:", " ")
     stampsLabel_knob.setFlag(nuke.STARTLINE)
-    buttonZoomNext = nuke.PyScript_Knob("zoomNext"," zoom next ","stamps.wiredZoomNext()")
+    buttonZoomNext = nuke.PyScript_Knob("zoomNext", " zoom next ", "stamps.wiredZoomNext()")
     buttonZoomNext.setTooltip("Navigate to this Stamp's next sibling on the Node Graph.")
     buttonZoomNext.clearFlag(nuke.STARTLINE)
-    buttonSelectSimilar = nuke.PyScript_Knob("selectSimilar"," select similar ","stamps.wiredSelectSimilar()")
+    buttonSelectSimilar = nuke.PyScript_Knob("selectSimilar", " select similar ", "stamps.wiredSelectSimilar()")
     buttonSelectSimilar.clearFlag(nuke.STARTLINE)
     buttonSelectSimilar.setTooltip("Select all similar Stamps to this one on the Node Graph.")
 
@@ -838,14 +1131,14 @@ def wired(anchor):
         n.addKnob(k)
 
     # Reconnect Simple
-    reconnectLabel_knob = nuke.Text_Knob('reconnect_label','Reconnect:', " ")
+    reconnectLabel_knob = nuke.Text_Knob("reconnect_label", "Reconnect:", " ")
     reconnectLabel_knob.setTooltip("Reconnect by the stored Anchor name.")
     reconnectLabel_knob.setFlag(nuke.STARTLINE)
-    buttonReconnectThis = nuke.PyScript_Knob("reconnect_this","this",wiredReconnect_code)
+    buttonReconnectThis = nuke.PyScript_Knob("reconnect_this", "this", wiredReconnect_code)
     buttonReconnectThis.setTooltip("Reconnect this Stamp to its Anchor, by its stored Anchor name.")
-    buttonReconnectSimilar = nuke.PyScript_Knob("reconnect_similar","similar","stamps.wiredReconnectSimilar()")
+    buttonReconnectSimilar = nuke.PyScript_Knob("reconnect_similar", "similar", "stamps.wiredReconnectSimilar()")
     buttonReconnectSimilar.setTooltip("Reconnect this Stamp and similar ones to their Anchor, by their stored anchor name.")
-    buttonReconnectAll = nuke.PyScript_Knob("reconnect_all","all","stamps.wiredReconnectAll()")
+    buttonReconnectAll = nuke.PyScript_Knob("reconnect_all", "all", "stamps.wiredReconnectAll()")
     buttonReconnectAll.setTooltip("Reconnect all the Stamps to their Anchors, by their stored anchor names.")
     space_2_knob = nuke.Text_Knob("space_2", "", " ")
     space_2_knob.setFlag(nuke.STARTLINE)
@@ -854,85 +1147,147 @@ def wired(anchor):
         n.addKnob(k)
 
     # Advanced Reconnection
-    advancedReconnection_knob = nuke.Tab_Knob('advanced_reconnection', 'Advanced Reconnection', nuke.TABBEGINCLOSEDGROUP)
+    advancedReconnection_knob = nuke.Tab_Knob("advanced_reconnection", "Advanced Reconnection", nuke.TABBEGINCLOSEDGROUP)
     n.addKnob(advancedReconnection_knob)
 
-    reconnectByTitleLabel_knob = nuke.Text_Knob('reconnect_by_title_label','<font color=gold>By Title:', " ")
+    reconnectByTitleLabel_knob = nuke.Text_Knob("reconnect_by_title_label", "<font color=gold>By Title:", " ")
     reconnectByTitleLabel_knob.setFlag(nuke.STARTLINE)
     reconnectByTitleLabel_knob.setTooltip("Reconnect by searching for a matching title.")
-    buttonReconnectByTitleThis = nuke.PyScript_Knob("reconnect_by_title_this","this","stamps.wiredReconnectByTitle()")
-    buttonReconnectByTitleThis.setTooltip("Look for an Anchor that shares this Stamp's title, and connect this Stamp to it.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work.")
-    buttonReconnectByTitleSimilar = nuke.PyScript_Knob("reconnect_by_title_similar","similar","stamps.wiredReconnectByTitleSimilar()")
-    buttonReconnectByTitleSimilar.setTooltip("Look for an Anchor that shares this Stamp's title, and connect this Stamp and similar ones to it.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work.")
-    buttonReconnectByTitleSelected = nuke.PyScript_Knob("reconnect_by_title_selected","selected","stamps.wiredReconnectByTitleSelected()")
-    buttonReconnectByTitleSelected.setTooltip("For each Stamp selected, look for an Anchor that shares its title, and connect to it.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work.")
-    reconnectBySelectionLabel_knob = nuke.Text_Knob('reconnect_by_selection_label','<font color=orangered>By Selection:', " ")
+    buttonReconnectByTitleThis = nuke.PyScript_Knob("reconnect_by_title_this", "this", "stamps.wiredReconnectByTitle()")
+    buttonReconnectByTitleThis.setTooltip(
+        "Look for an Anchor that shares this Stamp's title, and connect this Stamp to it.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work."
+    )
+    buttonReconnectByTitleSimilar = nuke.PyScript_Knob("reconnect_by_title_similar", "similar", "stamps.wiredReconnectByTitleSimilar()")
+    buttonReconnectByTitleSimilar.setTooltip(
+        "Look for an Anchor that shares this Stamp's title, and connect this Stamp and similar ones to it.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work."
+    )
+    buttonReconnectByTitleSelected = nuke.PyScript_Knob(
+        "reconnect_by_title_selected",
+        "selected",
+        "stamps.wiredReconnectByTitleSelected()",
+    )
+    buttonReconnectByTitleSelected.setTooltip(
+        "For each Stamp selected, look for an Anchor that shares its title, and connect to it.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work."
+    )
+    reconnectBySelectionLabel_knob = nuke.Text_Knob("reconnect_by_selection_label", "<font color=orangered>By Selection:", " ")
     reconnectBySelectionLabel_knob.setFlag(nuke.STARTLINE)
     reconnectBySelectionLabel_knob.setTooltip("Force reconnect to a selected Anchor.")
-    buttonReconnectBySelectionThis = nuke.PyScript_Knob("reconnect_by_selection_this","this","stamps.wiredReconnectBySelection()")
-    buttonReconnectBySelectionThis.setTooltip("Force reconnect this Stamp to a selected Anchor, whatever its name or title.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work.")
-    buttonReconnectBySelectionSimilar = nuke.PyScript_Knob("reconnect_by_selection_similar","similar","stamps.wiredReconnectBySelectionSimilar()")
-    buttonReconnectBySelectionSimilar.setTooltip("Force reconnect this Stamp and similar ones to a selected Anchor, whatever its name or title.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work.")
-    buttonReconnectBySelectionSelected = nuke.PyScript_Knob("reconnect_by_selection_selected","selected","stamps.wiredReconnectBySelectionSelected()")
-    buttonReconnectBySelectionSelected.setTooltip("Force reconnect all selected Stamps to an also selected Anchor, whatever its name or title.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work.")
-    
-    checkboxReconnectByTitleOnCreation = nuke.Boolean_Knob("auto_reconnect_by_title","<font color=#ED9977>&nbsp; auto-reconnect by title")
-    checkboxReconnectByTitleOnCreation.setTooltip("When creating this stamp again (like on copy-paste), auto-reconnect it by title instead of doing it by the saved anchor's name, and auto-turn this off immediately.\nIMPORTANT: Should be off by default. Only use this for setting up templates.")
+    buttonReconnectBySelectionThis = nuke.PyScript_Knob("reconnect_by_selection_this", "this", "stamps.wiredReconnectBySelection()")
+    buttonReconnectBySelectionThis.setTooltip(
+        "Force reconnect this Stamp to a selected Anchor, whatever its name or title.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work."
+    )
+    buttonReconnectBySelectionSimilar = nuke.PyScript_Knob(
+        "reconnect_by_selection_similar",
+        "similar",
+        "stamps.wiredReconnectBySelectionSimilar()",
+    )
+    buttonReconnectBySelectionSimilar.setTooltip(
+        "Force reconnect this Stamp and similar ones to a selected Anchor, whatever its name or title.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work."
+    )
+    buttonReconnectBySelectionSelected = nuke.PyScript_Knob(
+        "reconnect_by_selection_selected",
+        "selected",
+        "stamps.wiredReconnectBySelectionSelected()",
+    )
+    buttonReconnectBySelectionSelected.setTooltip(
+        "Force reconnect all selected Stamps to an also selected Anchor, whatever its name or title.\nIMPORTANT: Use this carefully, and only when the normal reconnection doesn't work."
+    )
+
+    checkboxReconnectByTitleOnCreation = nuke.Boolean_Knob("auto_reconnect_by_title", "<font color=#ED9977>&nbsp; auto-reconnect by title")
+    checkboxReconnectByTitleOnCreation.setTooltip(
+        "When creating this stamp again (like on copy-paste), auto-reconnect it by title instead of doing it by the saved anchor's name, and auto-turn this off immediately.\nIMPORTANT: Should be off by default. Only use this for setting up templates."
+    )
     checkboxReconnectByTitleOnCreation.setFlag(nuke.STARTLINE)
 
-    advancedReconnection_knob = nuke.Tab_Knob('advanced_reconnection', 'Advanced Reconnection', -1)
+    advancedReconnection_knob = nuke.Tab_Knob("advanced_reconnection", "Advanced Reconnection", -1)
 
-    for k in [reconnectByTitleLabel_knob, buttonReconnectByTitleThis, buttonReconnectByTitleSimilar, buttonReconnectByTitleSelected,
-              reconnectBySelectionLabel_knob, buttonReconnectBySelectionThis, buttonReconnectBySelectionSimilar, buttonReconnectBySelectionSelected,
-              anchor_knob, checkboxReconnectByTitleOnCreation,advancedReconnection_knob]:
+    for k in [
+        reconnectByTitleLabel_knob,
+        buttonReconnectByTitleThis,
+        buttonReconnectByTitleSimilar,
+        buttonReconnectByTitleSelected,
+        reconnectBySelectionLabel_knob,
+        buttonReconnectBySelectionThis,
+        buttonReconnectBySelectionSimilar,
+        buttonReconnectBySelectionSelected,
+        anchor_knob,
+        checkboxReconnectByTitleOnCreation,
+        advancedReconnection_knob,
+    ]:
         n.addKnob(k)
 
     # Version (for future update checks)
     line_knob = nuke.Text_Knob("line2", "", "")
-    buttonHelp = nuke.PyScript_Knob("buttonHelp","Help","stamps.showHelp()")
-    version_knob = nuke.Text_Knob('version',' ','<a href="http://www.nukepedia.com/gizmos/other/stamps" style="color:#666;text-decoration: none;"><span style="color:#666"> <big>Stamps {}</big></b></a>'.format(version))
+    buttonHelp = nuke.PyScript_Knob("buttonHelp", "Help", "stamps.showHelp()")
+    version_knob = nuke.Text_Knob(
+        "version",
+        " ",
+        '<a href="http://www.nukepedia.com/gizmos/other/stamps" style="color:#666;text-decoration: none;"><span style="color:#666"> <big>Stamps {}</big></b></a>'.format(
+            version
+        ),
+    )
     version_knob.clearFlag(nuke.STARTLINE)
     version_knob.setTooltip(VERSION_TOOLTIP)
     for k in [line_knob, buttonHelp, version_knob]:
         n.addKnob(k)
 
     # Hide input while not messing position
-    x,y = n.xpos(),n.ypos()
+    x, y = n.xpos(), n.ypos()
     nw = n.screenWidth()
     aw = anchor.screenWidth()
-    n.setInput(0,anchor)
+    n.setInput(0, anchor)
     n["hide_input"].setValue(True)
-    n["xpos"].setValue(x-nw/2+aw/2)
+    n["xpos"].setValue(x - nw / 2 + aw / 2)
     n["ypos"].setValue(y)
 
     n["help"].setValue(STAMPS_HELP)
 
     wiredTagsAndBackdrops(n)
 
+    # overwrite Tile color to follow Anchor Color
+    try:
+        setColorFromAnchor(n)
+    except Exception:
+        pass
+
+    n.setYpos(n.ypos() + 25)
+
     return n
     Stamps_LastCreated = anchor.name()
 
-def getAvailableName(name = "Untitled", rand=False):
-    ''' Returns a node name starting with @name followed by a number, that doesn't exist already '''
+
+def getAvailableName(name="Untitled", rand=False):
+    """Returns a node name starting with @name followed by a number, that doesn't exist already"""
     import random
+
     i = 1
     while True:
         if not rand:
-            available_name = name+str(i)
+            available_name = name + str(i)
         else:
-            available_name = name+str('_%09x' % random.randrange(9**12))
+            available_name = name + str("_%09x" % random.randrange(9**12))
         if not nuke.exists(available_name):
             return available_name
         i += 1
 
+
+def getRandomName(name="Untitled"):
+    """Returns a node name starting with @name followed by a number"""
+    import random
+
+    available_name = name + str("_%09x" % random.randrange(9**12))
+    return available_name
+
+
 #################################
-### CLASSES
+# CLASSES
 #################################
 
+
 class AnchorSelector(QtWidgets.QDialog):
-    '''
+    """
     Panel to select one or more anchors, showing the different anchors on dropdowns based on their tags.
-    '''
+    """
 
     # TODO LATER:
     # - Have three columns, distinguished, like an asset loader. Maybe even with border color?
@@ -944,19 +1299,21 @@ class AnchorSelector(QtWidgets.QDialog):
         self.setWindowTitle("Stamps: Select an Anchor.")
         self.chosen_anchors = []
         self.initUI()
-        #self.setFixedSize(self.sizeHint())
-        #self.setFixedWidth(self.sizeHint()[0])
+        # self.setFixedSize(self.sizeHint())
+        # self.setFixedWidth(self.sizeHint()[0])
         self.custom_anchors_lineEdit.setFocus()
 
     def initUI(self):
         # Find all anchors and get all tags
-        self.findAnchorsAndTags() # Generate a dictionary: {"Camera1":["Camera","New","Custom1"],"Read":["2D","New"]}
-        self.custom_chosen = False # If clicked OK on the custom lineedit
+        self.findAnchorsAndTags()  # Generate a dictionary: {"Camera1":["Camera","New","Custom1"],"Read":["2D","New"]}
+        self.custom_chosen = False  # If clicked OK on the custom lineedit
 
         # Header
         self.headerTitle = QtWidgets.QLabel("Anchor Stamp Selector")
         self.headerTitle.setStyleSheet("font-weight:bold;color:#CCCCCC;font-size:14px;")
-        self.headerSubtitle = QtWidgets.QLabel("Select an Anchor to make a Stamp for.<br/><b><small style='color:#CCC'>Right click on the OK buttons for multiple selection.</small></b>")
+        self.headerSubtitle = QtWidgets.QLabel(
+            "Select an Anchor to make a Stamp for.<br/><b><small style='color:#CCC'>Right click on the OK buttons for multiple selection.</small></b>"
+        )
         self.headerSubtitle.setStyleSheet("color:#999")
 
         self.headerLine = QtWidgets.QFrame()
@@ -966,12 +1323,11 @@ class AnchorSelector(QtWidgets.QDialog):
         self.headerLine.setMidLineWidth(1)
         self.headerLine.setFrameShadow(QtWidgets.QFrame.Sunken)
 
-
         # Layouts
         self.master_layout = QtWidgets.QVBoxLayout()
         self.master_layout.addWidget(self.headerTitle)
         self.master_layout.addWidget(self.headerSubtitle)
-        #self.master_layout.addWidget(self.headerLine)
+        # self.master_layout.addWidget(self.headerLine)
 
         # Main Scroll area
         self.scroll_content = QtWidgets.QWidget()
@@ -988,13 +1344,13 @@ class AnchorSelector(QtWidgets.QDialog):
         self.scroll.setFrameStyle(QtWidgets.QFrame.Panel | QtWidgets.QFrame.Sunken)
 
         self.grid = QtWidgets.QGridLayout()
-        #self.grid.setSpacing(0)
+        # self.grid.setSpacing(0)
         self.lower_grid = QtWidgets.QGridLayout()
 
         self.scroll_layout.addLayout(self.grid)
         self.scroll_layout.addStretch()
-        self.scroll_layout.setContentsMargins(2,2,2,2)
-        self.grid.setContentsMargins(2,2,2,2)
+        self.scroll_layout.setContentsMargins(2, 2, 2, 2)
+        self.grid.setContentsMargins(2, 2, 2, 2)
         self.grid.setSpacing(5)
 
         num_tags = len(self._all_tags)
@@ -1007,12 +1363,12 @@ class AnchorSelector(QtWidgets.QDialog):
         middleLine.setMidLineWidth(1)
         middleLine.setFrameShadow(QtWidgets.QFrame.Sunken)
 
-        if len(list(filter(None,self._all_tags)))>0:
+        if len(list(filter(None, self._all_tags))) > 0:
             tags_label = QtWidgets.QLabel("<i>Tags")
             tags_label.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
             tags_label.setStyleSheet("color:#666;margin:0px;padding:0px;padding-left:3px")
-            #self.grid.addWidget(middleLine,tag_num*10-6,1,2,3)
-            self.grid.addWidget(tags_label,0,0,1,3)
+            # self.grid.addWidget(middleLine,tag_num*10-6,1,2,3)
+            self.grid.addWidget(tags_label, 0, 0, 1, 3)
 
         for tag_num, tag in enumerate(self._all_tags_and_backdrops):
             if tag == "":
@@ -1027,8 +1383,8 @@ class AnchorSelector(QtWidgets.QDialog):
                 backdrops_label = QtWidgets.QLabel(" <i> Backdrops")
                 backdrops_label.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
                 backdrops_label.setStyleSheet("color:#666;margin:0px;padding:0px;padding-left:3px")
-                #self.grid.addWidget(middleLine,tag_num*10-5,0,1,3)
-                self.grid.addWidget(backdrops_label,tag_num*10-3,0,1,1)
+                # self.grid.addWidget(middleLine,tag_num*10-5,0,1,3)
+                self.grid.addWidget(backdrops_label, tag_num * 10 - 3, 0, 1, 1)
 
             tag_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
 
@@ -1046,7 +1402,7 @@ class AnchorSelector(QtWidgets.QDialog):
 
                 if cur_name not in tag_dict.keys():
                     continue
-                
+
                 if tag in tag_dict[cur_name]:
                     if title_repeated:
                         anchors_dropdown.addItem("{0} ({1})".format(cur_title, cur_name), cur_name)
@@ -1054,17 +1410,15 @@ class AnchorSelector(QtWidgets.QDialog):
                         anchors_dropdown.addItem(cur_title, cur_name)
 
             ok_btn = QtWidgets.QPushButton("OK")
-            ok_btn.clicked.connect(partial(self.okPressed,dropdown=anchors_dropdown))
+            ok_btn.clicked.connect(partial(self.okPressed, dropdown=anchors_dropdown))
 
             ok_btn.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-            ok_btn.setMaximumWidth(ok_btn.sizeHint().width()-19)
-            ok_btn.customContextMenuRequested.connect(partial(self.okRightClicked,anchors_dropdown))
+            ok_btn.setMaximumWidth(ok_btn.sizeHint().width() - 19)
+            ok_btn.customContextMenuRequested.connect(partial(self.okRightClicked, anchors_dropdown))
 
-
-            self.grid.addWidget(tag_label,tag_num*10+1,0)
-            self.grid.addWidget(anchors_dropdown,tag_num*10+1,1)
-            self.grid.addWidget(ok_btn,tag_num*10+1,2)
-
+            self.grid.addWidget(tag_label, tag_num * 10 + 1, 0)
+            self.grid.addWidget(anchors_dropdown, tag_num * 10 + 1, 1)
+            self.grid.addWidget(ok_btn, tag_num * 10 + 1, 2)
 
         # ALL
         tag_num = len(self._all_tags_and_backdrops)
@@ -1072,8 +1426,8 @@ class AnchorSelector(QtWidgets.QDialog):
         all_tag_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
         self.all_anchors_dropdown = QtWidgets.QComboBox()
 
-        all_tag_texts = [] # List of all texts of the items (usually equals the "title", or "title (name)")
-        all_tag_names = [i for i in self._all_anchors_names] # List of all real anchor names of the items.
+        all_tag_texts = []  # List of all texts of the items (usually equals the "title", or "title (name)")
+        all_tag_names = [i for i in self._all_anchors_names]  # List of all real anchor names of the items.
         for i, cur_name in enumerate(self._all_anchors_names):
             cur_title = self._all_anchors_titles[i]
             title_repeated = self._all_anchors_titles.count(cur_title)
@@ -1081,43 +1435,50 @@ class AnchorSelector(QtWidgets.QDialog):
                 all_tag_texts.append("{0} ({1})".format(cur_title, cur_name))
             else:
                 all_tag_texts.append(cur_title)
-        self.all_tag_sorted = sorted(list(zip(all_tag_texts,all_tag_names)),  key=lambda pair: pair[0].lower())
+        self.all_tag_sorted = sorted(list(zip(all_tag_texts, all_tag_names)), key=lambda pair: pair[0].lower())
 
         for [text, name] in self.all_tag_sorted:
             self.all_anchors_dropdown.addItem(text, name)
 
         all_ok_btn = QtWidgets.QPushButton("OK")
-        all_ok_btn.clicked.connect(partial(self.okPressed,dropdown=self.all_anchors_dropdown))
+        all_ok_btn.clicked.connect(partial(self.okPressed, dropdown=self.all_anchors_dropdown))
 
         all_ok_btn.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        all_ok_btn.customContextMenuRequested.connect(partial(self.okRightClicked,self.all_anchors_dropdown))
+        all_ok_btn.customContextMenuRequested.connect(partial(self.okRightClicked, self.all_anchors_dropdown))
 
-        self.lower_grid.addWidget(all_tag_label,tag_num,0)
-        self.lower_grid.addWidget(self.all_anchors_dropdown,tag_num,1)
-        self.lower_grid.addWidget(all_ok_btn,tag_num,2)
+        self.lower_grid.addWidget(all_tag_label, tag_num, 0)
+        self.lower_grid.addWidget(self.all_anchors_dropdown, tag_num, 1)
+        self.lower_grid.addWidget(all_ok_btn, tag_num, 2)
         tag_num += 1
 
         # POPULAR
-        tag_num = len(self._all_tags_and_backdrops)+10
+        tag_num = len(self._all_tags_and_backdrops) + 10
         popular_tag_label = QtWidgets.QLabel("<b>popular</b>: ")
         popular_tag_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
         self.popular_anchors_dropdown = QtWidgets.QComboBox()
-        all_tag_texts = [] # List of all texts of the items (usually equals the "title", or "title (name)")
-        all_tag_names = [i for i in self._all_anchors_names] # List of all real anchor names of the items.
-        all_tag_count = [stampCount(i) for i in self._all_anchors_names] # Number of stamps for each anchor!
+        all_tag_texts = []  # List of all texts of the items (usually equals the "title", or "title (name)")
+        all_tag_names = [i for i in self._all_anchors_names]  # List of all real anchor names of the items.
+        all_tag_count = [stampCount(i) for i in self._all_anchors_names]  # Number of stamps for each anchor!
 
-        popular_tag_texts = [] # List of popular texts of the items (usually equals the "title (x2)", or "title (name) (x2)")
-        sorted_names_and_titles = [(x,y) for (_,x,y) in sorted(list(zip(all_tag_count,self._all_anchors_names,self._all_anchors_titles)),reverse=True)]
-        popular_anchors_names = [x for x,_ in sorted_names_and_titles]
-        popular_anchors_titles = [x for _,x in sorted_names_and_titles]
-        #popular_anchors_titles = [x for _,x in sorted(zip(all_tag_count,self._all_anchors_titles),reverse=True)]
-        popular_anchors_count = sorted(all_tag_count,reverse=True)
+        # List of popular texts of the items (usually equals the "title (x2)", or "title (name) (x2)")
+        popular_tag_texts = []
+        sorted_names_and_titles = [
+            (x, y)
+            for (_, x, y) in sorted(
+                list(zip(all_tag_count, self._all_anchors_names, self._all_anchors_titles)),
+                reverse=True,
+            )
+        ]
+        popular_anchors_names = [x for x, _ in sorted_names_and_titles]
+        popular_anchors_titles = [x for _, x in sorted_names_and_titles]
+        # popular_anchors_titles = [x for _,x in sorted(zip(all_tag_count,self._all_anchors_titles),reverse=True)]
+        popular_anchors_count = sorted(all_tag_count, reverse=True)
 
         for i, cur_name in enumerate(popular_anchors_names):
             cur_title = popular_anchors_titles[i]
             title_repeated = popular_anchors_titles.count(cur_title)
             if title_repeated > 1:
-                popular_tag_texts.append("{0} ({1}) (x{2})".format(cur_title, cur_name,str(popular_anchors_count[i])))
+                popular_tag_texts.append("{0} ({1}) (x{2})".format(cur_title, cur_name, str(popular_anchors_count[i])))
             else:
                 popular_tag_texts.append("{0} (x{1})".format(cur_title, str(popular_anchors_count[i])))
 
@@ -1125,21 +1486,21 @@ class AnchorSelector(QtWidgets.QDialog):
             self.popular_anchors_dropdown.addItem(text, popular_anchors_names[i])
 
         popular_ok_btn = QtWidgets.QPushButton("OK")
-        popular_ok_btn.clicked.connect(partial(self.okPressed,dropdown=self.popular_anchors_dropdown))
+        popular_ok_btn.clicked.connect(partial(self.okPressed, dropdown=self.popular_anchors_dropdown))
 
         popular_ok_btn.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        popular_ok_btn.customContextMenuRequested.connect(partial(self.okRightClicked,self.popular_anchors_dropdown))
+        popular_ok_btn.customContextMenuRequested.connect(partial(self.okRightClicked, self.popular_anchors_dropdown))
 
-        self.lower_grid.addWidget(popular_tag_label,tag_num,0)
-        self.lower_grid.addWidget(self.popular_anchors_dropdown,tag_num,1)
-        self.lower_grid.addWidget(popular_ok_btn,tag_num,2)
+        self.lower_grid.addWidget(popular_tag_label, tag_num, 0)
+        self.lower_grid.addWidget(self.popular_anchors_dropdown, tag_num, 1)
+        self.lower_grid.addWidget(popular_ok_btn, tag_num, 2)
         tag_num += 1
 
         # LineEdit with completer
         custom_tag_label = QtWidgets.QLabel("<b>by title</b>: ")
         custom_tag_label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
         self.custom_anchors_lineEdit = QtWidgets.QLineEdit()
-        self.custom_anchors_completer = QtWidgets.QCompleter([i for i,_ in self.all_tag_sorted], self)
+        self.custom_anchors_completer = QtWidgets.QCompleter([i for i, _ in self.all_tag_sorted], self)
         self.custom_anchors_completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
         self.custom_anchors_completer.setCompletionMode(QtWidgets.QCompleter.InlineCompletion)
         self.custom_anchors_lineEdit.setCompleter(self.custom_anchors_completer)
@@ -1148,38 +1509,38 @@ class AnchorSelector(QtWidgets.QDialog):
             try:
                 title = nuke.toNode(Stamps_LastCreated)["title"].value()
                 self.custom_anchors_lineEdit.setPlaceholderText(title)
-            except:
+            except Exception:
                 pass
 
         custom_ok_btn = QtWidgets.QPushButton("OK")
-        custom_ok_btn.clicked.connect(partial(self.okCustomPressed,dropdown=self.custom_anchors_lineEdit))
+        custom_ok_btn.clicked.connect(partial(self.okCustomPressed, dropdown=self.custom_anchors_lineEdit))
 
         custom_ok_btn.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        custom_ok_btn.customContextMenuRequested.connect(partial(self.okCustomRightClicked,self.custom_anchors_lineEdit))
+        custom_ok_btn.customContextMenuRequested.connect(partial(self.okCustomRightClicked, self.custom_anchors_lineEdit))
 
-        self.lower_grid.addWidget(custom_tag_label,tag_num,0)
-        self.lower_grid.addWidget(self.custom_anchors_lineEdit,tag_num,1)
-        self.lower_grid.addWidget(custom_ok_btn,tag_num,2)
+        self.lower_grid.addWidget(custom_tag_label, tag_num, 0)
+        self.lower_grid.addWidget(self.custom_anchors_lineEdit, tag_num, 1)
+        self.lower_grid.addWidget(custom_ok_btn, tag_num, 2)
 
-        for i in [self.all_anchors_dropdown,self.popular_anchors_dropdown]:
+        for i in [self.all_anchors_dropdown, self.popular_anchors_dropdown]:
             i.setSizeAdjustPolicy(QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToContentsOnFirstShow)
             i.setMinimumWidth(200)
-            i.resize(500,i.sizeHint().height())
-            i.setSizePolicy(QtWidgets.QSizePolicy.Ignored,i.sizePolicy().verticalPolicy())
+            i.resize(500, i.sizeHint().height())
+            i.setSizePolicy(QtWidgets.QSizePolicy.Ignored, i.sizePolicy().verticalPolicy())
 
         # Layout shit
-        self.grid.setColumnStretch(1,1)
-        if len(list(filter(None,self._all_tags_and_backdrops))):
+        self.grid.setColumnStretch(1, 1)
+        if len(list(filter(None, self._all_tags_and_backdrops))):
             self.master_layout.addWidget(self.scroll)
         else:
             self.master_layout.addWidget(self.headerLine)
         self.master_layout.addLayout(self.lower_grid)
         self.setLayout(self.master_layout)
-        self.resize(self.sizeHint().width(),min(self.sizeHint().height()+10,700))
-        #self.setFixedWidth(self.sizeHint().width()+40)
+        self.resize(self.sizeHint().width(), min(self.sizeHint().height() + 10, 700))
+        # self.setFixedWidth(self.sizeHint().width()+40)
 
     def keyPressEvent(self, e):
-        selectorType = type(self.focusWidget()).__name__ #QComboBox or QLineEdit
+        selectorType = type(self.focusWidget()).__name__  # QComboBox or QLineEdit
         if e.key() == 16777220:
             if selectorType == "QLineEdit":
                 self.okCustomPressed(dropdown=self.focusWidget())
@@ -1195,18 +1556,19 @@ class AnchorSelector(QtWidgets.QDialog):
 
         self._all_tags = set()
         self._all_backdrops = set()
-        self._backdrop_item_count = {} # Number of anchors per backdrop
+        self._backdrop_item_count = {}  # Number of anchors per backdrop
         self._all_tags_and_backdrops = set()
-        self._anchors_and_tags = {} # Name:tags. Not title.
-        self._anchors_and_tags_tags = {} # Name:tags. Not title.
-        self._anchors_and_tags_backdrops = {} # Name:tags. Not title.
+        self._anchors_and_tags = {}  # Name:tags. Not title.
+        self._anchors_and_tags_tags = {}  # Name:tags. Not title.
+        self._anchors_and_tags_backdrops = {}  # Name:tags. Not title.
         for ni in allAnchors():
             try:
                 title_value = ni["title"].value()
                 name_value = ni.name()
                 tags_value = ni["tags"].value()
-                tags = re.split(" *, *",tags_value.strip()) # Remove leading/trailing spaces and separate by commas (with or without spaces)
-                #backdrop_tags = ["$b$"+x for x in backdropTags(ni)]
+                # Remove leading/trailing spaces and separate by commas (with or without spaces)
+                tags = re.split(" *, *", tags_value.strip())
+                # backdrop_tags = ["$b$"+x for x in backdropTags(ni)]
                 backdrop_tags = backdropTags(ni)
                 for t in backdrop_tags:
                     if t not in self._backdrop_item_count:
@@ -1221,14 +1583,14 @@ class AnchorSelector(QtWidgets.QDialog):
                 self._anchors_and_tags[name_value] = set(tags_and_backdrops)
                 self._anchors_and_tags_tags[name_value] = set(tags)
                 self._anchors_and_tags_backdrops[name_value] = set(backdrop_tags)
-            except:
+            except Exception:
                 pass
 
-        self._all_backdrops = sorted(list(self._all_backdrops), key = lambda x: -self._backdrop_item_count[x])
-        self._all_tags = sorted(list(self._all_tags),key=str.lower)
+        self._all_backdrops = sorted(list(self._all_backdrops), key=lambda x: -self._backdrop_item_count[x])
+        self._all_tags = sorted(list(self._all_tags), key=str.lower)
         self._all_tags_and_backdrops = self._all_tags + self._all_backdrops
 
-        #titles_upper = [x.upper() for x in self._all_anchors_titles]
+        # titles_upper = [x.upper() for x in self._all_anchors_titles]
 
         titles_and_names = list(zip(self._all_anchors_titles, self._all_anchors_names))
         titles_and_names.sort(key=lambda tup: tup[0].upper())
@@ -1259,17 +1621,18 @@ class AnchorSelector(QtWidgets.QDialog):
 
         # Count titles repetition
         title_repetitions = titles_with_tag.count(title)
-        return (title_repetitions > 1)
+        return title_repetitions > 1
 
     def okPressed(self, dropdown, close=True):
-        ''' Runs after an ok button is pressed '''
+        """Runs after an ok button is pressed"""
+
         dropdown_value = dropdown.currentText()
         dropdown_index = dropdown.currentIndex()
         dropdown_data = dropdown.itemData(dropdown_index)
 
         try:
             match_anchor = nuke.toNode(dropdown_data)
-        except:
+        except Exception:
             pass
 
         self.chosen_value = dropdown_value
@@ -1282,17 +1645,17 @@ class AnchorSelector(QtWidgets.QDialog):
             nuke.message("There was a problem selecting a valid anchor.")
 
     def okRightClicked(self, dropdown, position):
-        self.okPressed(dropdown,close=False)
+        self.okPressed(dropdown, close=False)
 
     def okCustomPressed(self, dropdown, close=True):
-        ''' Runs after the custom ok button is pressed '''
+        """Runs after the custom ok button is pressed"""
         global Stamps_LastCreated
-        written_value = dropdown.text() # This means it's been written down on the lineEdit
+        written_value = dropdown.text()  # This means it's been written down on the lineEdit
         written_lower = written_value.lower().strip()
 
         found_data = None
 
-        if written_value == "" and 'Stamps_LastCreated' in globals():
+        if written_value == "" and "Stamps_LastCreated" in globals():
             found_data = Stamps_LastCreated
         else:
             for [text, name] in reversed(self.all_tag_sorted):
@@ -1303,7 +1666,7 @@ class AnchorSelector(QtWidgets.QDialog):
                     found_data = name
         try:
             match_anchor = nuke.toNode(found_data)
-        except:
+        except Exception:
             nuke.message("Please write a valid name.")
             return
 
@@ -1317,10 +1680,12 @@ class AnchorSelector(QtWidgets.QDialog):
             nuke.message("There was a problem selecting a valid anchor.")
 
     def okCustomRightClicked(self, dropdown, position):
-        self.okCustomPressed(dropdown,close=False)
+        self.okCustomPressed(dropdown, close=False)
+
 
 class AnchorTags_LineEdit(QtWidgets.QLineEdit):
     new_text = QtCore.Signal(object, object)
+
     def __init__(self, *args):
         QtWidgets.QLineEdit.__init__(self, *args)
         self.textChanged.connect(self.text_changed)
@@ -1328,13 +1693,13 @@ class AnchorTags_LineEdit(QtWidgets.QLineEdit):
 
     def text_changed(self, text):
         all_text = unicode(text)
-        text = all_text[:self.cursorPosition()]
-        prefix = text.split(',')[-1].strip()
+        text = all_text[: self.cursorPosition()]
+        prefix = text.split(",")[-1].strip()
 
         text_tags = []
-        for t in all_text.split(','):
+        for t in all_text.split(","):
             t1 = unicode(t).strip()
-            if t1 != '':
+            if t1 != "":
                 text_tags.append(t.strip())
         text_tags = list(set(text_tags))
         self.new_text.emit(text_tags, prefix)
@@ -1346,35 +1711,46 @@ class AnchorTags_LineEdit(QtWidgets.QLineEdit):
         cursor_pos = self.cursorPosition()
         before_text = unicode(self.text())[:cursor_pos]
         after_text = unicode(self.text())[cursor_pos:]
-        prefix_len = len(before_text.split(',')[-1].strip())
-        if after_text.strip() == '':
-            self.setText('%s%s' % (before_text[:cursor_pos - prefix_len], text))
+        prefix_len = len(before_text.split(",")[-1].strip())
+        if after_text.strip() == "":
+            self.setText("%s%s" % (before_text[: cursor_pos - prefix_len], text))
         else:
-            self.setText('%s%s, %s' % (before_text[:cursor_pos - prefix_len], text, after_text))
+            self.setText("%s%s, %s" % (before_text[: cursor_pos - prefix_len], text, after_text))
         self.setCursorPosition(cursor_pos - prefix_len + len(text) + 2)
+
 
 class TagsCompleter(QtWidgets.QCompleter):
     insertText = QtCore.Signal(str)
+
     def __init__(self, all_tags):
         QtWidgets.QCompleter.__init__(self, all_tags)
         self.all_tags = set(all_tags)
         self.activated.connect(self.activated_text)
 
     def update(self, text_tags, completion_prefix):
-        tags = list(self.all_tags-set(text_tags))
+        tags = list(self.all_tags - set(text_tags))
         model = QtCore.QStringListModel(tags, self)
         self.setModel(model)
         self.setCompletionPrefix(completion_prefix)
         self.complete()
 
-    def activated_text(self,completion):
+    def activated_text(self, completion):
         self.insertText.emit(completion)
 
+
 class NewAnchorPanel(QtWidgets.QDialog):
-    '''
+    """
     Panel to create a new anchor on a selected node, where you can choose the name (autocompleted at first) and tags.
-    '''
-    def __init__(self, windowTitle = "New Stamp", default_title="", all_tags = [], default_tags = "", parent = None):
+    """
+
+    def __init__(
+        self,
+        windowTitle="New Stamp",
+        default_title="",
+        all_tags=[],
+        default_tags="",
+        parent=None,
+    ):
         super(NewAnchorPanel, self).__init__(parent)
 
         self.default_title = default_title
@@ -1425,10 +1801,10 @@ class NewAnchorPanel(QtWidgets.QDialog):
         """Create layout..."""
 
         self.titleAndTags_layout = QtWidgets.QGridLayout()
-        self.titleAndTags_layout.addWidget(self.anchorTitle_label,0,0)
-        self.titleAndTags_layout.addWidget(self.anchorTitle_edit,0,1)
-        self.titleAndTags_layout.addWidget(self.anchorTags_label,1,0)
-        self.titleAndTags_layout.addWidget(self.anchorTags_edit,1,1)
+        self.titleAndTags_layout.addWidget(self.anchorTitle_label, 0, 0)
+        self.titleAndTags_layout.addWidget(self.anchorTitle_edit, 0, 1)
+        self.titleAndTags_layout.addWidget(self.anchorTags_label, 1, 0)
+        self.titleAndTags_layout.addWidget(self.anchorTags_edit, 1, 1)
 
         self.master_layout = QtWidgets.QVBoxLayout()
         self.master_layout.addWidget(self.newAnchorTitle)
@@ -1447,14 +1823,16 @@ class NewAnchorPanel(QtWidgets.QDialog):
         return True
 
     def clickedCancel(self):
-        '''Abort mission'''
+        """Abort mission"""
         self.reject()
 
+
 class AddTagsPanel(QtWidgets.QDialog):
-    '''
+    """
     Panel to add tags to the selected Stamps or nodes.
-    '''
-    def __init__(self, all_tags = [], default_tags = "", parent = None):
+    """
+
+    def __init__(self, all_tags=[], default_tags="", parent=None):
         super(AddTagsPanel, self).__init__(parent)
 
         self.all_tags = all_tags
@@ -1505,14 +1883,14 @@ class AddTagsPanel(QtWidgets.QDialog):
 
     def createLayouts(self):
         self.main_layout = QtWidgets.QGridLayout()
-        self.main_layout.addWidget(self.tags_label,0,0)
-        self.main_layout.addWidget(self.tags_edit,0,1)
+        self.main_layout.addWidget(self.tags_label, 0, 0)
+        self.main_layout.addWidget(self.tags_edit, 0, 1)
 
         addTo_Buttons_layout = QtWidgets.QHBoxLayout()
         addTo_Buttons_layout.addWidget(self.addTo_btnA)
         addTo_Buttons_layout.addWidget(self.addTo_btnB)
-        self.main_layout.addWidget(self.addTo_Label,1,0)
-        self.main_layout.addLayout(addTo_Buttons_layout,1,1)
+        self.main_layout.addWidget(self.addTo_Label, 1, 0)
+        self.main_layout.addLayout(addTo_Buttons_layout, 1, 1)
 
         self.master_layout = QtWidgets.QVBoxLayout()
         self.master_layout.addWidget(self.addTagsTitle)
@@ -1523,21 +1901,23 @@ class AddTagsPanel(QtWidgets.QDialog):
         self.setLayout(self.master_layout)
 
     def clickedOk(self):
-        '''Check if all is correct and submit'''
+        """Check if all is correct and submit"""
         self.tags = self.tags_edit.text().strip()
         self.allNodes = self.addTo_btnA.isChecked
         self.accept()
         return True
 
     def clickedCancel(self):
-        '''Abort mission'''
+        """Abort mission"""
         self.reject()
 
+
 class RenameTagPanel(QtWidgets.QDialog):
-    '''
+    """
     Panel to rename a tag on the selected (or all) nodes.
-    '''
-    def __init__(self, all_tags = [], default_tags = "", parent = None):
+    """
+
+    def __init__(self, all_tags=[], default_tags="", parent=None):
         super(RenameTagPanel, self).__init__(parent)
 
         self.all_tags = all_tags
@@ -1592,16 +1972,16 @@ class RenameTagPanel(QtWidgets.QDialog):
 
     def createLayouts(self):
         self.main_layout = QtWidgets.QGridLayout()
-        self.main_layout.addWidget(self.tag_label,0,0)
-        self.main_layout.addWidget(self.tag_edit,0,1)
-        self.main_layout.addWidget(self.tagReplace_label,1,0)
-        self.main_layout.addWidget(self.tagReplace_edit,1,1)
+        self.main_layout.addWidget(self.tag_label, 0, 0)
+        self.main_layout.addWidget(self.tag_edit, 0, 1)
+        self.main_layout.addWidget(self.tagReplace_label, 1, 0)
+        self.main_layout.addWidget(self.tagReplace_edit, 1, 1)
 
         addTo_Buttons_layout = QtWidgets.QHBoxLayout()
         addTo_Buttons_layout.addWidget(self.addTo_btnA)
         addTo_Buttons_layout.addWidget(self.addTo_btnB)
-        self.main_layout.addWidget(self.addTo_Label,2,0)
-        self.main_layout.addLayout(addTo_Buttons_layout,2,1)
+        self.main_layout.addWidget(self.addTo_Label, 2, 0)
+        self.main_layout.addLayout(addTo_Buttons_layout, 2, 1)
 
         self.master_layout = QtWidgets.QVBoxLayout()
         self.master_layout.addWidget(self.headerTitle)
@@ -1612,7 +1992,7 @@ class RenameTagPanel(QtWidgets.QDialog):
         self.setLayout(self.master_layout)
 
     def clickedOk(self):
-        '''Check if all is correct and submit'''
+        """Check if all is correct and submit"""
         self.tag = self.tag_edit.text().strip()
         self.tagReplace = self.tagReplace_edit.text().strip()
         self.allNodes = self.addTo_btnB.isChecked
@@ -1620,35 +2000,37 @@ class RenameTagPanel(QtWidgets.QDialog):
         return True
 
     def clickedCancel(self):
-        '''Abort mission'''
+        """Abort mission"""
         self.reject()
 
+
 #################################
-### FUNCTIONS
+# FUNCTIONS
 #################################
 
-def getDefaultTitle(node = None):
-    if node == None:
+
+def getDefaultTitle(node=None):
+    if node is None:
         return False
     title = str(node.name())
 
     # Default defaults here
-     # cam
+    # cam
     if "Camera" in node.Class() and not any([(i.knob("title") and i["title"].value() == "cam") for i in nuke.allNodes("NoOp")]):
         title = "cam"
         return title
 
-    if node.Class() in ["Dot","NoOp"] and node["label"].value().strip() != "":
+    if node.Class() in ["Dot", "NoOp"] and node["label"].value().strip() != "":
         return node["label"].value().strip()
 
     # Filename
     try:
-        file = node['file'].value()
+        file = node["file"].value()
         if not (node.knob("read_from_file") and not node["read_from_file"].value()):
             if file != "":
-                rawname = file.rpartition('/')[2].rpartition('.')[0]
-                if '.' in rawname:
-                    rawname = rawname.rpartition('.')[0]
+                rawname = file.rpartition("/")[2].rpartition(".")[0]
+                if "." in rawname:
+                    rawname = rawname.rpartition(".")[0]
                 # 1: beauty?
                 m = re.match(r"([\w]+)_v[\d]+_beauty", rawname)
                 if m:
@@ -1656,15 +2038,16 @@ def getDefaultTitle(node = None):
                     title = "_".join(pre_version.split("_")[3:])
                     return title
                 # 2: Other
-                rawname = str(re.split("_v[0-9]*_",rawname)[-1]).replace("_render","")
+                rawname = str(re.split("_v[0-9]*_", rawname)[-1]).replace("_render", "")
                 title = rawname
-    except:
+    except Exception:
         pass
 
     return title
 
-def backdropTags(node = None):
-    ''' Returns the list of words belonging to the backdrop/s label/s'''
+
+def backdropTags(node=None):
+    """Returns the list of words belonging to the backdrop/s label/s"""
     backdrops = findBackdrops(node)
     tags = []
     for b in backdrops:
@@ -1676,30 +2059,31 @@ def backdropTags(node = None):
         label = b["label"].value()
         if len(label) and len(label) < 50 and not label.startswith("\\"):
             label = label.split("\n")[0].strip()
-            label = re.sub("<[^<>]>","",label)
-            label = re.sub("[\s]+"," ",label)
-            label = re.sub("\.$","",label)
+            label = re.sub("<[^<>]>", "", label)
+            label = re.sub("[\s]+", " ", label)
+            label = re.sub("\.$", "", label)
             label = label.strip()
             tags.append(label)
     return tags
 
-def stampCreateAnchor(node = None, extra_tags = [], no_default_tag = False):
-    '''
+
+def stampCreateAnchor(node=None, extra_tags=[], no_default_tag=False):
+    """
     Create a stamp from any nuke node.
     Returns: extra_tags list is success, None if cancelled
-    '''
+    """
     ns = nuke.selectedNodes()
     for n in ns:
         n.setSelected(False)
 
     if node is not None:
         node.setSelected(True)
-        default_title = getDefaultTitle(realInput(node,stopOnLabel=True,mode="title"))
-        default_tags = list(set([nodeType(realInput(node,mode="tags"))]))
+        default_title = getDefaultTitle(realInput(node, stopOnLabel=True, mode="title"))
+        default_tags = list(set([nodeType(realInput(node, mode="tags"))]))
         if node.Class() in ["ScanlineRender"]:
-            default_tags += ["2D","Deep"]
+            default_tags += ["2D", "Deep"]
         node_type = nodeType(realInput(node))
-        window_title = "New Stamp: "+str(node.name())
+        window_title = "New Stamp: " + str(node.name())
     else:
         default_title = "Stamp"
         default_tags = ""
@@ -1710,7 +2094,7 @@ def stampCreateAnchor(node = None, extra_tags = [], no_default_tag = False):
         custom_default_title = defaultTitle(node)
         if custom_default_title:
             default_title = str(custom_default_title)
-    except:
+    except Exception:
         pass
 
     try:
@@ -1721,7 +2105,7 @@ def stampCreateAnchor(node = None, extra_tags = [], no_default_tag = False):
             else:
                 default_tags = custom_default_tags
 
-    except:
+    except Exception:
         pass
 
     default_default_tags = default_tags
@@ -1729,7 +2113,7 @@ def stampCreateAnchor(node = None, extra_tags = [], no_default_tag = False):
     if no_default_tag:
         default_tags = ", ".join(extra_tags + [""])
     else:
-        default_tags = list(filter(None,list(dict.fromkeys(default_tags + extra_tags))))
+        default_tags = list(filter(None, list(dict.fromkeys(default_tags + extra_tags))))
         default_tags = ", ".join(default_tags + [""])
 
     global new_anchor_panel
@@ -1743,10 +2127,15 @@ def stampCreateAnchor(node = None, extra_tags = [], no_default_tag = False):
                 nuke.message("Please set a valid title.")
                 continue
             elif len(findAnchorsByTitle(anchor_title)):
-                if not nuke.ask("There is already a Stamp titled "+anchor_title+".\nDo you still want to use this title?"):
+                if not nuke.ask("There is already a Stamp titled " + anchor_title + ".\nDo you still want to use this title?"):
                     continue
-            na = anchor(title = anchor_title, tags = anchor_tags, input_node = node, node_type = node_type)
-            na.setYpos(na.ypos()+20)
+            na = anchor(
+                title=anchor_title,
+                tags=anchor_tags,
+                input_node=node,
+                node_type=node_type,
+            )
+            na.setYpos(na.ypos() + 20)
             stampCreateWired(na)
             for n in ns:
                 n.setSelected(True)
@@ -1756,17 +2145,18 @@ def stampCreateAnchor(node = None, extra_tags = [], no_default_tag = False):
             break
         else:
             break
-        
+
     return extra_tags
 
+
 def stampSelectAnchors():
-    '''
+    """
     Panel to select a stamp anchor (if there are any)
     Returns: selected anchor node, or None.
-    '''
+    """
     # 1.Get position where to make the child...
     nodeForPos = nuke.createNode("NoOp")
-    childNodePos = [nodeForPos.xpos(),nodeForPos.ypos()]
+    # childNodePos = [nodeForPos.xpos(), nodeForPos.ypos()]
     nuke.delete(nodeForPos)
     # 2.Choose the anchor...
     anchorList = [n.name() for n in allAnchors()]
@@ -1776,52 +2166,57 @@ def stampSelectAnchors():
     else:
         global select_anchors_panel
         select_anchors_panel = AnchorSelector()
-        if select_anchors_panel.exec_(): # If user clicks OK
+        if select_anchors_panel.exec_():  # If user clicks OK
             chosen_anchors = select_anchors_panel.chosen_anchors
             if chosen_anchors:
                 return chosen_anchors
         return None
 
-def stampCreateWired(anchor = ""):
-    ''' Create a wired stamp from an anchor node. '''
+
+def stampCreateWired(anchor=""):
+    """Create a wired stamp from an anchor node."""
     global Stamps_LastCreated
     nw = ""
     nws = []
     if anchor == "":
         anchors = stampSelectAnchors()
-        if anchorSelectWireds == None:
+        if anchorSelectWireds is None:
             return
         if anchors:
             for i, anchor in enumerate(anchors):
-                nw = wired(anchor = anchor)
-                nw.setInput(0,anchor)
+                nw = wired(anchor=anchor)
+                nw.setInput(0, anchor)
                 nws.append(nw)
-                if i>0:
-                    nws[i].setXYpos(nws[i-1].xpos()+100,nws[i-1].ypos())
+                if i > 0:
+                    nws[i].setXYpos(nws[i - 1].xpos() + 100, nws[i - 1].ypos() + 25)
 
     else:
         ns = nuke.selectedNodes()
         for n in ns:
             n.setSelected(False)
         dot = nuke.nodes.Dot()
-        dot.setXYpos(anchor.xpos(),anchor.ypos())
-        dot.setInput(0,anchor)
-        nw = wired(anchor = anchor)
+        dot.setXYpos(anchor.xpos(), anchor.ypos())
+        dot.setInput(0, anchor)
+        nw = wired(anchor=anchor)
         code = "dummy = nuke.nodes.{}()".format(nw.Class())
         namespace = {}
-        exec(code,globals(),namespace)
+        exec(code, globals(), namespace)
         dummy = namespace["dummy"]
         nww = dummy.screenWidth()
         nuke.delete(dummy)
         nuke.delete(dot)
         for n in ns:
             n.setSelected(True)
-        nw.setXYpos(int(anchor.xpos()+anchor.screenWidth()/2-nww/2) ,anchor.ypos()+56)
+        nw.setXYpos(
+            int(anchor.xpos() + anchor.screenWidth() / 2 - nww / 2),
+            anchor.ypos() + 56 + 25,
+        )
         anchor.setSelected(False)
     return nw
 
-def stampCreateByTitle(title = ""):
-    ''' Create a wired stamp given a title. '''
+
+def stampCreateByTitle(title=""):
+    """Create a wired stamp given a title."""
     global Stamps_LastCreated
 
     anchor = None
@@ -1829,15 +2224,16 @@ def stampCreateByTitle(title = ""):
         if a.knob("title") and a["title"].value() == title:
             anchor = a
             break
-    if anchor == None:
+    if anchor is None:
         return
 
-    nw = wired(anchor = anchor)
-    nw.setInput(0,anchor)
+    nw = wired(anchor=anchor)
+    nw.setInput(0, anchor)
     return nw
 
-def stampDuplicateWired(wired = ""):
-    ''' Create a duplicate of a wired stamp '''
+
+def stampDuplicateWired(wired=""):
+    """Create a duplicate of a wired stamp"""
     ns = nuke.selectedNodes()
     for n in ns:
         n.setSelected(False)
@@ -1849,17 +2245,18 @@ def stampDuplicateWired(wired = ""):
     wired.setSelected(False)
     new_wired = nuke.nodePaste("%clipboard%")
     clipboard.setText(ctext)
-    new_wired.setXYpos(wired.xpos()-110,wired.ypos()+55)
+    new_wired.setXYpos(wired.xpos() - 110, wired.ypos() + 55)
     try:
-        new_wired.setInput(0,wired.input(0))
-    except:
+        new_wired.setInput(0, wired.input(0))
+    except Exception:
         pass
     for n in ns:
         n.setSelected(True)
     wired.setSelected(False)
 
-def stampType(n = ""):
-    ''' Returns the identifier value if it exists, otherwise False. '''
+
+def stampType(n=""):
+    """Returns the identifier value if it exists, otherwise False."""
     if isAnchor(n):
         return "anchor"
     elif isWired(n):
@@ -1867,91 +2264,105 @@ def stampType(n = ""):
     else:
         return False
 
+
 def nodeType(n=""):
-    '''Returns the node type: Camera, Deep, 3D, Particles, 2D or False'''
+    """Returns the node type: Camera, Deep, 3D, Particles, 2D or False"""
     try:
         nodeClass = n.Class()
-    except:
+    except Exception:
         return False
-    if nodeClass.startswith("Deep") and nodeClass not in DeepExceptionClasses:
+    if (nodeClass.startswith("Deep") or "imagetodeep" in nodeClass.lower()) and nodeClass not in DeepExceptionClasses:
         return "Deep"
     elif nodeClass.startswith("Particle") and nodeClass not in ParticleExceptionClasses:
         return "Particle"
     elif nodeClass.startswith("ScanlineRender"):
         return False
-    elif nodeClass in ["Camera", "Camera2", "Camera3"]:
+    elif nodeClass in ["Camera", "Camera2", "Camera3", "Camera4"]:
         return "Camera"
-    elif nodeClass in ["Axis", "Axis2","Axis3"]:
+    elif nodeClass in ["Axis", "Axis2", "Axis3"]:
         return "Axis"
-    elif (n.knob("render_mode") and n.knob("display")) or nodeClass in ["GeoNoOp","EditGeo"]:
+    elif (n.knob("render_mode") and n.knob("display")) or nodeClass in ["GeoNoOp", "EditGeo"]:
         return "3D"
     else:
         return "2D"
+
 
 def allAnchors(selection=""):
     nodes = nuke.allNodes()
     if selection == "":
         anchors = [a for a in nodes if isAnchor(a)]
     else:
-        anchors = [a for a in nodes if a in selection and isAnchor(a)]    
+        anchors = [a for a in nodes if a in selection and isAnchor(a)]
     return anchors
+
 
 def allWireds(selection=""):
     nodes = nuke.allNodes()
     if selection == "":
         wireds = [a for a in nodes if isWired(a)]
     else:
-        wireds = [a for a in nodes if a in selection and isWired(a)]   
+        wireds = [a for a in nodes if a in selection and isWired(a)]
     return wireds
+
 
 def totalAnchors(selection=""):
     num_anchors = len(allAnchors(selection))
     return num_anchors
+
 
 def allTags(selection=""):
     all_tags = set()
     for ni in allAnchors():
         try:
             tags_value = ni["tags"].value()
-            tags = re.split(" *, *",tags_value.strip()) # Remove leading/trailing spaces and separate by commas (with or without spaces)
+            # Remove leading/trailing spaces and separate by commas (with or without spaces)
+            tags = re.split(" *, *", tags_value.strip())
             all_tags.update(tags)
-        except:
+        except Exception:
             pass
 
     all_tags = [i for i in list(all_tags) if i]
     all_tags.sort(key=str.lower)
     return all_tags
 
-def findAnchorsByTitle(title = "", selection=""):
-    ''' Returns list of nodes '''
+
+def findAnchorsByTitle(title="", selection=""):
+    """Returns list of nodes"""
+
     if title == "":
         return None
+
+    all_anchors = allAnchors()
+
     if selection == "":
-        found_anchors = [a for a in allAnchors() if a.knob("title") and a.knob("title").value() == title]
+        found_anchors = [a for a in all_anchors if a.knob("title") and a.knob("title").value() == title]
     else:
-        found_anchors = [a for a in selection if a in allAnchors() and a.knob("title") and a.knob("title").value() == title]
+        found_anchors = [a for a in selection if a in all_anchors and a.knob("title") and a.knob("title").value() == title]
     return found_anchors
 
+
 def titleIsLegal(title=""):
-    '''
+    """
     Convenience function to determine which stamp titles are legal.
     titleIsLegal(title) -> True or False
-    '''
-    if not title or title == "":
-        return False
-    return True
+    """
+
+    return bool(title)
+
 
 def isAnchor(node=""):
-    ''' True or False '''
-    return True if all(node.knob(i) for i in ["identifier","title"]) and node["identifier"].value() == "anchor" else False
+    """True or False"""
+    return node.knob("identifier") and node["identifier"].value() == "anchor"
+
 
 def isWired(node=""):
-    ''' True or False '''
-    return True if all(node.knob(i) for i in ["identifier","title"]) and node["identifier"].value() == "wired" else False
+    """True or False"""
+    return node.knob("identifier") and node["identifier"].value() == "wired"
 
-def findBackdrops(node = ""):
-    ''' Returns a list containing the backdrops that contain the given node.'''
-    if node =="":
+
+def findBackdrops(node=""):
+    """Returns a list containing the backdrops that contain the given node."""
+    if node == "":
         return []
     x = node.xpos()
     y = node.ypos()
@@ -1960,38 +2371,45 @@ def findBackdrops(node = ""):
 
     backdrops = []
     for b in nuke.allNodes("BackdropNode"):
-        bx = int(b['xpos'].value())
-        by = int(b['ypos'].value())
-        br = int(b['bdwidth'].value())+bx
-        bt =int(b['bdheight'].value())+by
-        if x >= bx and (x+w) <= br and y > by and (y+h) <= bt:
+        bx = int(b["xpos"].value())
+        by = int(b["ypos"].value())
+        br = int(b["bdwidth"].value()) + bx
+        bt = int(b["bdheight"].value()) + by
+        if x >= bx and (x + w) <= br and y > by and (y + h) <= bt:
             backdrops.append(b)
     return backdrops
 
+
 def realInput(node, stopOnLabel=False, mode=""):
-    '''
+    """
     Returns the first input node that is not a Dot or a Stamp
     stopOnLabel=False. True: Stop when it's a dot or NoOp but it has a label.
     mode="title": ignores TitleIgnoreClasses
     mode="tags": ignores TagsIgnoreClasses
-    '''
+    """
     try:
         n = node
-        if stampType(n) or n.Class() in InputIgnoreClasses or (mode=="title" and n.Class() in TitleIgnoreClasses) or (mode=="tags" and n.Class() in TagsIgnoreClasses):
-            if stopOnLabel and n.knob("label") and n["label"].value().strip()!="":
+        if (
+            stampType(n)
+            or n.Class() in InputIgnoreClasses
+            or (mode == "title" and n.Class() in TitleIgnoreClasses)
+            or (mode == "tags" and n.Class() in TagsIgnoreClasses)
+        ):
+            if stopOnLabel and n.knob("label") and n["label"].value().strip() != "":
                 return n
             if n.input(0):
                 n = n.input(0)
-                return realInput(n,stopOnLabel,mode)
+                return realInput(n, stopOnLabel, mode)
             else:
                 return n
         else:
             return n
-    except:
+    except Exception:
         return node
 
-def nodeToScript(node = ""):
-    ''' Returns a node as a tcl string, similar as nodecopy without messing with the clipboard '''
+
+def nodeToScript(node=""):
+    """Returns a node as a tcl string, similar as nodecopy without messing with the clipboard"""
     orig_sel_nodes = nuke.selectedNodes()
     if node == "":
         node = nuke.selectedNode()
@@ -2010,8 +2428,9 @@ def nodeToScript(node = ""):
         i.setSelected(True)
     return node_as_script
 
-def nodesFromScript(script = ""):
-    ''' Returns string as a node, similar as nodepaste without messing with the clipboard '''
+
+def nodesFromScript(script=""):
+    """Returns string as a node, similar as nodepaste without messing with the clipboard"""
     if script == "":
         return
     clipboard = QtWidgets.QApplication.clipboard()
@@ -2021,14 +2440,16 @@ def nodesFromScript(script = ""):
     clipboard.setText(ctext)
     return True
 
+
 def stampCount(anchor_name=""):
-    if anchor_name=="":
+    if anchor_name == "":
         return len(allWireds())
     stamps = [s for s in allWireds() if s["anchor"].value() == anchor_name]
     return len(stamps)
 
+
 def toNoOp(node=""):
-    '''Turns a given node into a NoOp that shares everything else'''
+    """Turns a given node into a NoOp that shares everything else"""
     global Stamps_LockCallbacks
     Stamps_LockCallbacks = True
     if node == "":
@@ -2038,17 +2459,32 @@ def toNoOp(node=""):
     nsn = nuke.selectedNodes()
     [i.setSelected(False) for i in nsn]
     scr = nodeToScript(node)
-    scr = re.sub(r"\n[\s]*[\w]+[\s]*{\n","\nNoOp {\n",scr)
-    scr = re.sub(r"^[\s]*[\w]+[\s]*{\n","NoOp {\n",scr)
+    scr = re.sub(r"\n[\s]*[\w]+[\s]*{\n", "\nNoOp {\n", scr)
+    scr = re.sub(r"^[\s]*[\w]+[\s]*{\n", "NoOp {\n", scr)
 
-    legal_starts = ["set","version","push","NoOp","help","onCreate","name","knobChanged","autolabel","tile_color","gl_color","note_font","selected","hide_input"]
+    legal_starts = [
+        "set",
+        "version",
+        "push",
+        "NoOp",
+        "help",
+        "onCreate",
+        "name",
+        "knobChanged",
+        "autolabel",
+        "tile_color",
+        "gl_color",
+        "note_font",
+        "selected",
+        "hide_input",
+    ]
 
-    scr_split = scr.split("addUserKnob",1)
+    scr_split = scr.split("addUserKnob", 1)
     scr_first = scr_split[0].split("\n")
     for i, line in enumerate(scr_first):
-        if not any([line.startswith(x) or line.startswith(" "+x) for x in legal_starts]):
+        if not any([line.startswith(x) or line.startswith(" " + x) for x in legal_starts]):
             scr_first[i] = ""
-    scr_first = "\n".join([i for i in scr_first if i]+[""])
+    scr_first = "\n".join([i for i in scr_first if i] + [""])
     scr_split[0] = scr_first
 
     scr = "addUserKnob".join(scr_split)
@@ -2056,36 +2492,38 @@ def toNoOp(node=""):
     node.setSelected(True)
     xp = node.xpos()
     yp = node.ypos()
-    xw = node.screenWidth()/2
+    xw = node.screenWidth() / 2
     d = nuke.createNode("Dot")
-    d.setInput(0,node)
+    d.setInput(0, node)
     inp = None
     [i.setSelected(True) for i in nsn]
     nuke.delete(node)
     d.setSelected(False)
     d.setSelected(True)
-    d.setXYpos(int(xp+xw-d.screenWidth()/2),yp-18)
+    d.setXYpos(int(xp + xw - d.screenWidth() / 2), yp - 18)
     nodesFromScript(scr)
     n = nuke.selectedNode()
-    n.setXYpos(xp,yp)
+    n.setXYpos(xp, yp)
     nuke.delete(d)
     for i in nsn:
         try:
             i.setSelected(True)
-        except:
+        except Exception:
             pass
     Stamps_LockCallbacks = False
 
+
 def allToNoOp():
-    ''' Turns all the stamps into NoOps '''
+    """Turns all the stamps into NoOps"""
     for n in nuke.allNodes():
         if stampType(n) and n.Class() != "NoOp":
             toNoOp(n)
 
+
 def createWHotboxButtons():
-    ''' If the folder is available inside the stamps package, it gets appended into the W_Hotbox packages. '''
+    """If the folder is available inside the stamps package, it gets appended into the W_Hotbox packages."""
     # DONE W_Hotbox buttons imported from stamps extras path
-    w_hotbox_buttons_path = os.path.dirname(__file__).replace("\\","/")+"/includes/W_hotbox"
+    w_hotbox_buttons_path = os.path.dirname(__file__).replace("\\", "/") + "/includes/W_hotbox"
     if os.path.exists(w_hotbox_buttons_path):
         hotbox_paths = ""
         hotbox_names = ""
@@ -2096,30 +2534,32 @@ def createWHotboxButtons():
             hotbox_paths += os.pathsep
         if hotbox_names != "":
             hotbox_names += os.pathsep
-        os.environ["W_HOTBOX_REPO_PATHS"] = hotbox_paths + os.path.dirname(__file__).replace("\\","/")+"/includes/W_hotbox"
+        os.environ["W_HOTBOX_REPO_PATHS"] = hotbox_paths + os.path.dirname(__file__).replace("\\", "/") + "/includes/W_hotbox"
         os.environ["W_HOTBOX_REPO_NAMES"] = hotbox_names + "Stamps"
 
+
 #################################
-### Menu functions
+# Menu functions
 #################################
 
+
 def refreshStamps(ns=""):
-    '''Refresh all the wired Stamps in the script, to spot any wrong styles or connections.'''
+    """Refresh all the wired Stamps in the script, to spot any wrong styles or connections."""
     stamps = allWireds(ns)
     x = 0
     failed = []
     failed_names = []
     for s in stamps:
         if not wiredReconnect(s):
-            x += 1 # Errors
+            x += 1  # Errors
             failed.append(s)
         else:
             try:
                 s["reconnect_this"].execute()
-            except:
+            except Exception:
                 pass
     failed_names = ", ".join([i.name() for i in failed])
-    if x==0:
+    if x == 0:
         if ns == "":
             nuke.message("All Stamps refreshed! No errors detected.")
         else:
@@ -2132,16 +2572,17 @@ def refreshStamps(ns=""):
         else:
             nuke.message("Selected Stamps refreshed. Found {0} connection error/s:\n\n{1}".format(str(x), failed_names))
 
+
 def addTags(ns=""):
-    if ns=="":
+    if ns == "":
         ns = nuke.selectedNodes()
     if not len(ns):
         if not nuke.ask("Nothing is selected. Do you wish to add tags to ALL nodes in the script?"):
             return
         ns = nuke.allNodes()
-    
+
     global stamps_addTags_panel
-    stamps_addTags_panel = AddTagsPanel(all_tags = allTags(), default_tags = "")
+    stamps_addTags_panel = AddTagsPanel(all_tags=allTags(), default_tags="")
     if stamps_addTags_panel.exec_():
         all_nodes = stamps_addTags_panel.allNodes
         added_tags = stamps_addTags_panel.tags.strip()
@@ -2160,30 +2601,33 @@ def addTags(ns=""):
             elif all_nodes and n.Class() not in NodeExceptionClasses:
                 tags_knob = n.knob("stamp_tags")
                 if not tags_knob:
-                    tags_knob = nuke.String_Knob('stamp_tags','Stamp Tags', "")
-                    tags_knob.setTooltip("Stamps: Comma-separated tags you can define for each Anchor, that will help you find it when invoking the Stamp Selector by pressing the Stamps shortkey with nothing selected.")
+                    tags_knob = nuke.String_Knob("stamp_tags", "Stamp Tags", "")
+                    tags_knob.setTooltip(
+                        "Stamps: Comma-separated tags you can define for each Anchor, that will help you find it when invoking the Stamp Selector by pressing the Stamps shortkey with nothing selected."
+                    )
                     n.addKnob(tags_knob)
             else:
                 continue
             existing_tags = re.split(r"[\s]*,[\s]*", tags_knob.value().strip())
-            merged_tags = list(filter(None,list(set(existing_tags + added_tags))))
+            merged_tags = list(filter(None, list(set(existing_tags + added_tags))))
             tags_knob.setValue(", ".join(merged_tags))
             i += 1
             continue
-        if i>0:
+        if i > 0:
             if all_nodes:
                 nuke.message("Added the specified tag/s to {} nodes.".format(str(i)))
             else:
                 nuke.message("Added the specified tag/s to {} Anchor Stamps.".format(str(i)))
     return
 
+
 def renameTag(ns=""):
-    if ns=="":
+    if ns == "":
         ns = nuke.selectedNodes()
     if not len(ns):
         ns = nuke.allNodes()
     global stamps_renameTag_panel
-    stamps_renameTag_panel = RenameTagPanel(all_tags = allTags())
+    stamps_renameTag_panel = RenameTagPanel(all_tags=allTags())
     if stamps_renameTag_panel.exec_():
         all_nodes = stamps_renameTag_panel.allNodes
         if all_nodes:
@@ -2208,7 +2652,7 @@ def renameTag(ns=""):
             else:
                 continue
 
-            existing_tags = list(filter(None,re.split(r"[\s]*,[\s]*", tags_knob.value())))
+            existing_tags = list(filter(None, re.split(r"[\s]*,[\s]*", tags_knob.value())))
             added_tag_list = re.split(r"[\s]*,[\s]*", added_tag.strip())
             added_tagReplace_list = re.split(r"[\s]*,[\s]*", added_tagReplace)
 
@@ -2223,33 +2667,37 @@ def renameTag(ns=""):
                 tags_knob.setValue(", ".join(merged_tags))
                 i += 1
             continue
-        if i>0:
+        if i > 0:
             nuke.message("Renamed the specified tag on {} nodes.".format(str(i)))
     return
+
 
 def selectedReconnectByName():
     ns = [n for n in nuke.selectedNodes() if isWired(n)]
     for n in ns:
         try:
             n["reconnect_this"].execute()
-        except:
+        except Exception:
             pass
+
 
 def selectedReconnectByTitle():
     ns = [n for n in nuke.selectedNodes() if isWired(n)]
     for n in ns:
         try:
             n["reconnect_by_title_this"].execute()
-        except:
+        except Exception:
             pass
+
 
 def selectedReconnectBySelection():
     ns = [n for n in nuke.selectedNodes() if isWired(n)]
     for n in ns:
         try:
             n["reconnect_by_selection_this"].execute()
-        except:
+        except Exception:
             pass
+
 
 def selectedToggleAutorec():
     ns = [n for n in nuke.selectedNodes() if n.knob("auto_reconnect_by_title")]
@@ -2267,7 +2715,8 @@ def selectedToggleAutorec():
             n.knob("auto_reconnect_by_title").setValue(0)
             count += 1
         nuke.message("<b>auto-reconnect by title</b> is now <b>False</b> on {} selected stamps.".format(str(count)))
-        
+
+
 def selectedSelectSimilar():
     ns = [n for n in nuke.selectedNodes() if isWired(n) or isAnchor(n)]
     for n in ns:
@@ -2276,83 +2725,103 @@ def selectedSelectSimilar():
                 n["selectSimilar"].execute()
             if n.knob("selectStamps"):
                 n["selectStamps"].execute()
-        except:
+        except Exception:
             pass
+
 
 def showInNukepedia():
     from webbrowser import open as openUrl
+
     openUrl("http://www.nukepedia.com/gizmos/other/stamps")
+
 
 def showInGithub():
     from webbrowser import open as openUrl
+
     openUrl("https://github.com/adrianpueyo/stamps")
 
 
 def showHelp():
-     from webbrowser import open as openUrl
-     openUrl("http://www.adrianpueyo.com/Stamps_v1.1.pdf")
+    from webbrowser import open as openUrl
 
-def showVideo():        
-     from webbrowser import open as openUrl     
-     openUrl("https://vimeo.com/adrianpueyo/knobscripter2")
+    openUrl("http://www.adrianpueyo.com/Stamps_v1.1.pdf")
+
+
+def showVideo():
+    from webbrowser import open as openUrl
+
+    openUrl("https://vimeo.com/adrianpueyo/knobscripter2")
+
 
 def stampBuildMenus():
     global Stamps_MenusLoaded
+    if not nuke.GUI:
+        return
     if not Stamps_MenusLoaded:
         Stamps_MenusLoaded = True
-        m = nuke.menu('Nuke')
-        m.addCommand('Edit/Stamps/Make Stamp', 'stamps.goStamp()', STAMPS_SHORTCUT, icon="stamps.png")
-        m.addCommand('Edit/Stamps/Add tag\/s to selected nodes', 'stamps.addTags()')
-        m.addCommand('Edit/Stamps/Rename Stamp tag', 'stamps.renameTag()')
-        m.addCommand('Edit/Stamps/Refresh all Stamps', 'stamps.refreshStamps()')
-        m.addCommand('Edit/Stamps/Selected/Reconnect by Name', 'stamps.selectedReconnectByName()')
-        m.addCommand('Edit/Stamps/Selected/Reconnect by Title', 'stamps.selectedReconnectByTitle()')
-        m.addCommand('Edit/Stamps/Selected/Reconnect by Selection', 'stamps.selectedReconnectBySelection()')
-        m.menu('Edit').menu('Stamps').menu('Selected').addSeparator()
-        m.addCommand('Edit/Stamps/Selected/Refresh', 'stamps.refreshStamps(nuke.selectedNodes())')
-        m.addCommand('Edit/Stamps/Selected/Select Similar', 'stamps.selectedSelectSimilar()')
-        m.addCommand('Edit/Stamps/Selected/Toggle auto-rec... by title ', 'stamps.selectedToggleAutorec()')
+        m = nuke.menu("Nuke")
 
-        m.addCommand('Edit/Stamps/Advanced/Convert all Stamps to NoOp', 'stamps.allToNoOp()')
-        m.menu('Edit').menu('Stamps').addSeparator()
-        m.addCommand('Edit/Stamps/GitHub', 'stamps.showInGithub()')
-        m.addCommand('Edit/Stamps/Nukepedia', 'stamps.showInNukepedia()')
-        m.menu('Edit').menu('Stamps').addSeparator()
-        m.addCommand('Edit/Stamps/Video tutorials', 'stamps.showVideo()')
-        m.addCommand('Edit/Stamps/Documentation (.pdf)', 'stamps.showHelp()')
-        nuke.menu('Nodes').addCommand('Other/Stamps', 'stamps.goStamp()', STAMPS_SHORTCUT, icon="stamps.png")
+        if USE_LABELCONNECTOR_UI:
+            m.addCommand("Edit/Stamps/Make Stamp", "stamps.goStampsLabelConnector()", STAMPS_SHORTCUT, icon="stamps.png", shortcutContext=2)
+        else:
+            m.addCommand("Edit/Stamps/Make Stamp", "stamps.goStamp()", STAMPS_SHORTCUT, icon="stamps.png", shortcutContext=2)
+
+        m.addCommand("Edit/Stamps/Add tag\/s to selected nodes", "stamps.addTags()")
+        m.addCommand("Edit/Stamps/Rename Stamp tag", "stamps.renameTag()")
+        m.addCommand("Edit/Stamps/Refresh all Stamps", "stamps.refreshStamps()")
+        m.addCommand("Edit/Stamps/Selected/Reconnect by Name", "stamps.selectedReconnectByName()")
+        m.addCommand("Edit/Stamps/Selected/Reconnect by Title", "stamps.selectedReconnectByTitle()")
+        m.addCommand("Edit/Stamps/Selected/Reconnect by Selection", "stamps.selectedReconnectBySelection()")
+        m.menu("Edit").menu("Stamps").menu("Selected").addSeparator()
+        m.addCommand("Edit/Stamps/Selected/Refresh", "stamps.refreshStamps(nuke.selectedNodes())")
+        m.addCommand("Edit/Stamps/Selected/Select Similar", "stamps.selectedSelectSimilar()")
+        m.addCommand("Edit/Stamps/Selected/Toggle auto-rec... by title ", "stamps.selectedToggleAutorec()")
+
+        m.addCommand("Edit/Stamps/Advanced/Convert all Stamps to NoOp", "stamps.allToNoOp()")
+        m.menu("Edit").menu("Stamps").addSeparator()
+        m.addCommand("Edit/Stamps/GitHub", "stamps.showInGithub()")
+        m.addCommand("Edit/Stamps/Nukepedia", "stamps.showInNukepedia()")
+        m.menu("Edit").menu("Stamps").addSeparator()
+        m.addCommand("Edit/Stamps/Video tutorials", "stamps.showVideo()")
+        m.addCommand("Edit/Stamps/Documentation (.pdf)", "stamps.showHelp()")
+        m.menu("Edit").menu("Stamps").addSeparator()
+
+        m.addCommand("Edit/Stamps/show connections", "stamps.showConnections()", "shift+" + STAMPS_SHORTCUT, shortcutContext=2)
+        m.addCommand("Edit/Stamps/Jump to Anchor | Change Anchor Color", "stamps.jumpORcolor()", "ctrl+" + STAMPS_SHORTCUT, shortcutContext=2)
 
         createWHotboxButtons()
 
+
 def addIncludesPath():
-    includes_dir = os.path.join(os.path.dirname(__file__),"includes")
+    includes_dir = os.path.join(os.path.dirname(__file__), "includes")
     if os.path.isdir(includes_dir):
         nuke.pluginAddPath(includes_dir)
 
 
 #################################
-### MAIN IMPLEMENTATION
+# MAIN IMPLEMENTATION
 #################################
 
+
 def goStamp(ns=""):
-    ''' Main stamp function, the one that is called when pressing the main shortcut. '''
-    if ns=="":
+    """Main stamp function, the one that is called when pressing the main shortcut."""
+    if ns == "":
         ns = nuke.selectedNodes()
     if not len(ns):
-        if not totalAnchors(): # If no anchors on the script, create an anchor with no input
-            stampCreateAnchor(no_default_tag = True)
+        if not totalAnchors():  # If no anchors on the script, create an anchor with no input
+            stampCreateAnchor(no_default_tag=True)
         else:
-            stampCreateWired() # Selection panel in order to create a stamp
+            stampCreateWired()  # Selection panel in order to create a stamp
             return
     elif len(ns) == 1 and ns[0].Class() in NodeExceptionClasses:
-        if not totalAnchors(): # If no anchors on the script, return
+        if not totalAnchors():  # If no anchors on the script, return
             return
         else:
-            stampCreateWired() # Selection panel in order to create a stamp
+            stampCreateWired()  # Selection panel in order to create a stamp
             return
     else:
         # Warn if the selection is too big
-        if len(ns) > 10 and not nuke.ask("You have "+str(len(ns))+" nodes selected.\nDo you want make stamps for all of them?"):
+        if len(ns) > 10 and not nuke.ask("You have " + str(len(ns)) + " nodes selected.\nDo you want make stamps for all of them?"):
             return
         # Main loop
         extra_tags = []
@@ -2360,16 +2829,104 @@ def goStamp(ns=""):
             if n in NodeExceptionClasses:
                 continue
             elif isAnchor(n):
-                stampCreateWired(n) # Make a child to n
+                stampCreateWired(n)  # Make a child to n
             elif isWired(n):
-                stampDuplicateWired(n) # Make a copy of n next to it
+                stampDuplicateWired(n)  # Make a copy of n next to it
             else:
                 if n.knob("stamp_tags"):
-                    stampCreateAnchor(n, extra_tags = n.knob("stamp_tags").value().split(","), no_default_tag = True)
+                    stampCreateAnchor(n, extra_tags=n.knob("stamp_tags").value().split(","), no_default_tag=True)
                 else:
-                    extra_tags = stampCreateAnchor(n, extra_tags = extra_tags) # Create anchor via anchor creation panel
+                    extra_tags = stampCreateAnchor(n, extra_tags=extra_tags)  # Create anchor via anchor creation panel
                 if "Cryptomatte" in n.Class() and n.knob("matteOnly"):
-                    n['matteOnly'].setValue(1)
+                    n["matteOnly"].setValue(1)
+
+
+def showConnections():
+    """
+    SHIFT+STAMPS_SHORTCUT
+
+    Selects all Stamps based on the same Anchor.
+
+    """
+
+    ns = nuke.selectedNodes()
+
+    for n in ns:
+        n.setSelected(False)
+
+        if isAnchor(n):
+            anchorSelectWireds(n)
+
+        elif isWired(n):
+            wiredSelectSimilar(n.knob("anchor").getValue())
+
+
+def jumpKeepingPreviousSelection(node):
+    """
+    Jump to node without destroyng previous selection of nodes
+
+    Args:
+        node (node): any nuke node
+    """
+
+    prevNodes = nuke.selectedNodes()
+
+    for i in prevNodes:
+        i.setSelected(False)
+
+    node.setSelected(True)
+    nuke.zoomToFitSelected()
+    node.setSelected(False)
+
+    for i in prevNodes:
+        i.setSelected(True)
+
+
+def jumpORcolor():
+    """
+    CTRL+STAMPS_SHORTCUT
+
+    STAMP selected: Jump to its anchor.
+    ANCHOR selected: Change its color.
+
+    """
+
+    ns = nuke.selectedNodes()
+
+    if not ns:
+        return
+
+    n = ns[0]
+
+    if len(ns) == 1 and isWired(n):
+        a = nuke.toNode(n["anchor"].value())
+        jumpKeepingPreviousSelection(a)
+    else:
+        change_color_on_anchors()
+
+
+def change_color_on_anchors():
+    """changes the color of all selected anchors."""
+
+    selected_nodes = nuke.selectedNodes()
+    if selected_nodes and all([isAnchor(node) for node in selected_nodes]):
+        labelConnectorForStamps.showColorSelectionUI(selected_nodes)
+        return
+
+
+def goStampsLabelConnector():
+    """Main stamp function with new UI, the one that is called when pressing the main shortcut."""
+
+    selected_nodes = nuke.selectedNodes()
+    if not selected_nodes:
+        all_anchors = allAnchors()
+        if all_anchors:
+            labelConnectorForStamps.showConnector(all_anchors)
+            return
+
+    # no stamps existed
+    goStamp()
+
 
 stampBuildMenus()
 addIncludesPath()

--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -2047,7 +2047,7 @@ def getDefaultTitle(node=None):
 
 
 def backdropTags(node=None):
-    """Returns the list of words belonging to the backdrop/s label/s"""
+    """Returns a dict of words:backrop-node belonging to the backdrop/s label/s"""
     backdrops = findBackdrops(node)
     tags = dict()
     for b in backdrops:
@@ -2063,8 +2063,8 @@ def backdropTags(node=None):
             label = re.sub("[\s]+", " ", label)
             label = re.sub("\.$", "", label)
             label = label.strip()
-            if not label in tags.keys():
-                tags[label] = b
+            
+            tags[label] = b
                 
     return tags
 

--- a/stamps/stamps_config.py
+++ b/stamps/stamps_config.py
@@ -75,7 +75,7 @@ def getColorFromTags(tags=""):
 
     tags = tags.lower()
 
-    if "roto" in tags or "rotogroup" in tags or "mask" in tags or "crypto" in tags:
+    if any(tag in tags for tag in ["roto", "rotogroup", "mask", "crypto"]):
         return COLOR_LIST["Green"]
     elif "plates" in tags:
         return COLOR_LIST["Yellow"]
@@ -87,17 +87,19 @@ def getColorFromTags(tags=""):
     return None
 
 
-def setColorFromAnchor(Wired):
-    """set the color of the wired node to the color of the anchor node"""
+# moved to stamps.py
+# use this to override the color of the wired node based on the anchor node
+# def setColorFromAnchor(Wired):
+#     """set the color of the wired node to the color of the anchor node"""
 
-    n = Wired
-    anchor = n.dependencies(nuke.HIDDEN_INPUTS)[0]
-    anchor_color = anchor["tile_color"].getValue()
+#     n = Wired
+#     anchor = n.dependencies(nuke.HIDDEN_INPUTS)[0]
+#     anchor_color = anchor["tile_color"].getValue()
 
-    if anchor_color == int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16):
-        n["tile_color"].setValue(16777217)
+#     if anchor_color == int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16):
+#         n["tile_color"].setValue(16777217)
 
-    n["tile_color"].setValue(int(anchor_color))
+#     n["tile_color"].setValue(int(anchor_color))
 
 
 def defaultTitle(node):
@@ -145,8 +147,20 @@ def defaultTags(node):
 
     # Here's an example:
     node_class = node.Class()
-    if node_class == "Write":
-        tags.append("File Out")
+
+    if node_class == "Cryptomatte":
+        tags.append("crypto")
+
+    elif node_class == "Roto":
+        tags.append("roto")
+
+    elif node_class == "Read":
+        file = node.knob("file").value().lower()
+        if "roto" in file:
+            tags.append("rotogroup")
+
+    elif "Camera" in node_class:
+        tags.append("camera")
 
     # Now, the list of tags for whenever we create a Stamp on a Write node, will contain "File Out" by default.
 

--- a/stamps/stamps_config.py
+++ b/stamps/stamps_config.py
@@ -22,7 +22,7 @@ import nuke
 
 STAMPS_SHORTCUT = "F8"
 
-USE_LABELCONNECTOR_UI = True # restart nuke to take effect. True uses LabelConnector UI, False uses the previous UI
+USE_LABELCONNECTOR_UI = True  # restart nuke to take effect. True uses LabelConnector UI, False uses the previous UI
 
 ANCHOR_STYLE = {
     "tile_color": 4294967041,

--- a/stamps/stamps_config.py
+++ b/stamps/stamps_config.py
@@ -20,7 +20,7 @@ import nuke
 # 1. MAIN DEFAULTS
 # ----------------------------------------------
 
-STAMPS_SHORTCUT = "F8"
+STAMPS_SHORTCUT = "E"
 
 USE_LABELCONNECTOR_UI = True
 
@@ -163,11 +163,7 @@ def defaultTags(node):
 # ----------------------------------------------
 
 KEEP_ORIGINAL_TAGS = False  # True: Keep the default tags for the nodes, plus your custom-defined ones. False: Only keep the custom ones you can define below
-DeepExceptionClasses = [
-    "DeepToImage",
-    "DeepHoldout",
-    "DeepHoldout2",
-]  # Nodes with "Deep" in their class that don't classify as Deep.
+DeepExceptionClasses = ["DeepToImage", "DeepHoldout", "DeepHoldout2"]  # Nodes with "Deep" in their class that don't classify as Deep.
 NodeExceptionClasses = ["Viewer"]  # Nodes that won't accept stamps
 ParticleExceptionClasses = ["ParticleToImage"]  # Nodes with "Particle" in class and an input called "particles" that don't classify as particles.
 
@@ -176,22 +172,10 @@ ParticleExceptionClasses = ["ParticleToImage"]  # Nodes with "Particle" in class
 TitleIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 TagsIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 
-AnchorClassesAlt = {
-    "2D": "NoOp",
-    "Deep": "DeepExpression",
-    "3D": "EditGeo",
-    "Particle": "ParticleExpression",
-}
+AnchorClassesAlt = {"2D": "NoOp", "Deep": "DeepExpression", "3D": "EditGeo", "Particle": "ParticleExpression"}
 
 # modified for NoOp instead of PostageStamp
-StampClassesAlt = {
-    "2D": "NoOp",
-    "Deep": "DeepExpression",
-    "3D": "LookupGeo",
-    "Camera": "NoOp",
-    "Axis": "Axis",
-    "Particle": "ParticleExpression",
-}
+StampClassesAlt = {"2D": "NoOp", "Deep": "DeepExpression", "3D": "LookupGeo", "Camera": "NoOp", "Axis": "Axis", "Particle": "ParticleExpression"}
 
 # Use the dictionary above to define the base node classes you want for each type.
 # For any type you don't define, it will use a NoOp. Available types: 2D, 3D, Deep, Particle, Camera, Axis

--- a/stamps/stamps_config.py
+++ b/stamps/stamps_config.py
@@ -1,13 +1,15 @@
-#------------------------------------------------------
+# ------------------------------------------------------
 # Stamps by Adrian Pueyo and Alexey Kuchinski
 # Smart node connection system for Nuke
 # adrianpueyo.com, 2018-2020
-config_version= "v1.1"
-date = "May 16 2020"
-#-----------------------------------------------------
-import nuke
-import os
+config_version = "v2.0"
+date = "Nov 2023"
+# -----------------------------------------------------
+# import os
 import re
+
+import nuke
+
 # ----------------------------------------------
 # INSTRUCTIONS:
 # Modify this file as needed. Do not rename it.
@@ -20,35 +22,93 @@ import re
 
 STAMPS_SHORTCUT = "F8"
 
+USE_LABELCONNECTOR_UI = True
+
 ANCHOR_STYLE = {
     "tile_color": 4294967041,
     "note_font_size": 20,
-    }
+}
 
 STAMP_STYLE = {
     "tile_color": 16777217,
     "note_font_size": 20,
     "postage_stamp": 0,
-    }
+}
+
+# colors for the getColorFromTags to automatically color Anchors
+# this is not used for the color quick menu
+COLOR_LIST = {
+    "Red": 1277436927,
+    "Orange": 2017657087,
+    "Yellow": 2154504703,
+    "Green": 793519103,
+    "Dark Green": 304619007,
+    "Cyan": 592071935,
+    "Blue": 556482559,
+    "Dark Blue": 320482047,
+    "Purple": 975388415,
+    "Default": 673720575,
+    "Deep": int("%02x%02x%02x%02x" % (40, 40, 100, 1), 16),
+}
 
 # Override tile_color for specific node classes, to be fancy.
-AnchorClassColors = {"Camera":int('%02x%02x%02x%02x' % (255,255,255,1),16),}
-WiredClassColors = {"Camera":int('%02x%02x%02x%02x' % (51,0,0,1),16),}
+AnchorClassColors = {
+    "Camera": int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16),
+}
+WiredClassColors = {
+    "Camera": int("%02x%02x%02x%02x" % (51, 0, 0, 1), 16),
+    "Deep": int("%02x%02x%02x%02x" % (40, 40, 100, 1), 16),
+}
+# WiredClassColors = {"Deep":int('%02x%02x%02x%02x' % (40,40,100,1),16),}
 
 
 # ----------------------------------------------
 # 2. CUSTOM FUNCTIONS
 # ----------------------------------------------
 
+
+def getColorFromTags(tags=""):
+    """return a color based on tags"""
+
+    if isinstance(tags, list):
+        tags = " ".join(tags)
+
+    tags = tags.lower()
+
+    if "roto" in tags or "rotogroup" in tags or "mask" in tags or "crypto" in tags:
+        return COLOR_LIST["Green"]
+    elif "plates" in tags:
+        return COLOR_LIST["Yellow"]
+    elif "deep" in tags:
+        return COLOR_LIST["Deep"]
+    elif "camera" in tags:
+        return COLOR_LIST["Red"]
+
+    return None
+
+
+def setColorFromAnchor(Wired):
+    """set the color of the wired node to the color of the anchor node"""
+
+    n = Wired
+    anchor = n.dependencies(nuke.HIDDEN_INPUTS)[0]
+    anchor_color = anchor["tile_color"].getValue()
+
+    if anchor_color == int("%02x%02x%02x%02x" % (255, 255, 255, 1), 16):
+        n["tile_color"].setValue(16777217)
+
+    n["tile_color"].setValue(int(anchor_color))
+
+
 def defaultTitle(node):
-    '''
+    """
     defaultTitle(node) -> (str)title
     Returns a custom default Stamp title for a given node.
     Customize this function to return any string you want.
     If you return None, it will calculate the default title.
-    '''
-    
-    name = node.name()
+    """
+
+    # name = node.name()
 
     # ALL THIS IS SAMPLE CODE, FEEL FREE TO REMOVE OR MODIFY IT
     # Example 1: Make "cam" the default Stamp title for the first Camera
@@ -57,32 +117,32 @@ def defaultTitle(node):
         return title
 
     # Example 2: If the node has a file knob, take the part of the filename that goes before the frame numbers
-    if node.knob("file"): # If node has knob "file"
+    if node.knob("file"):  # If node has knob "file"
         filepath = node.knob("file").value()
-        if filepath: # If the value of the knob "file" is not empty
-            filename = filepath.split("/")[-1] # 1. Take the file name only
-            title = filename.split(".")[0] # 2. Take the part of the filename before any dots
-            title = str(re.split("_v[0-9]*_",title)[-1]) # 3. Take the part that goes after the version
-            title = title.replace("_render","") # 4. If the title includes "_render", remove it
+        if filepath:  # If the value of the knob "file" is not empty
+            filename = filepath.split("/")[-1]  # 1. Take the file name only
+            title = filename.split(".")[0]  # 2. Take the part of the filename before any dots
+            title = str(re.split("_v[0-9]*_", title)[-1])  # 3. Take the part that goes after the version
+            title = title.replace("_render", "")  # 4. If the title includes "_render", remove it
             return title
-
 
     # If we don't return a string, stamps.py will calculate the default title by itself.
     return
 
+
 def defaultTags(node):
-    '''
+    """
     defaultTags(node) -> (list of str)tags
     Returns a custom default list of Stamp tags for a given node.
     Customize this function to return any string you want.
     If you return None, it will calculate the default tags.
-    '''
+    """
 
     # 1. We start off with an empty list
     tags = []
 
     # 2. Now we can add any custom default tags (strings) to the list, by making any calculations on the node.
-    
+
     # Here's an example:
     node_class = node.Class()
     if node_class == "Write":
@@ -97,23 +157,41 @@ def defaultTags(node):
 
     return tags
 
+
 # ----------------------------------------------
 # 3. ADVANCED. DO NOT CHANGE UNLESS NEEDED.
 # ----------------------------------------------
 
-KEEP_ORIGINAL_TAGS = True # True: Keep the default tags for the nodes, plus your custom-defined ones. False: Only keep the custom ones you can define below
-DeepExceptionClasses = ["DeepToImage","DeepHoldout","DeepHoldout2"] # Nodes with "Deep" in their class that don't classify as Deep.
-NodeExceptionClasses = ["Viewer"] # Nodes that won't accept stamps
-ParticleExceptionClasses = ["ParticleToImage"] # Nodes with "Particle" in class and an input called "particles" that don't classify as particles.
+KEEP_ORIGINAL_TAGS = False  # True: Keep the default tags for the nodes, plus your custom-defined ones. False: Only keep the custom ones you can define below
+DeepExceptionClasses = [
+    "DeepToImage",
+    "DeepHoldout",
+    "DeepHoldout2",
+]  # Nodes with "Deep" in their class that don't classify as Deep.
+NodeExceptionClasses = ["Viewer"]  # Nodes that won't accept stamps
+ParticleExceptionClasses = ["ParticleToImage"]  # Nodes with "Particle" in class and an input called "particles" that don't classify as particles.
 
 # The next two constants define the node classes that will be ignored when looking for the title or tags of a node.
 # This means, it will look for the node's first input instead, recursively, until it finds a node that doesn't belong to these classes.
 TitleIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 TagsIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 
-AnchorClassesAlt = {"2D":"NoOp", "Deep":"DeepExpression", "3D":"EditGeo", "Particle":"ParticleExpression"}
-AnchorClassesAlt = {"2D":"NoOp"}
-StampClassesAlt = {"2D":"PostageStamp", "Deep":"DeepExpression", "3D":"LookupGeo", "Camera":"DummyCam", "Axis":"Axis","Particle":"ParticleExpression"}
+AnchorClassesAlt = {
+    "2D": "NoOp",
+    "Deep": "DeepExpression",
+    "3D": "EditGeo",
+    "Particle": "ParticleExpression",
+}
+
+# modified for NoOp instead of PostageStamp
+StampClassesAlt = {
+    "2D": "NoOp",
+    "Deep": "DeepExpression",
+    "3D": "LookupGeo",
+    "Camera": "NoOp",
+    "Axis": "Axis",
+    "Particle": "ParticleExpression",
+}
 
 # Use the dictionary above to define the base node classes you want for each type.
 # For any type you don't define, it will use a NoOp. Available types: 2D, 3D, Deep, Particle, Camera, Axis

--- a/stamps/stamps_config.py
+++ b/stamps/stamps_config.py
@@ -20,9 +20,9 @@ import nuke
 # 1. MAIN DEFAULTS
 # ----------------------------------------------
 
-STAMPS_SHORTCUT = "E"
+STAMPS_SHORTCUT = "F8"
 
-USE_LABELCONNECTOR_UI = True
+USE_LABELCONNECTOR_UI = True # restart nuke to take effect. True uses LabelConnector UI, False uses the previous UI
 
 ANCHOR_STYLE = {
     "tile_color": 4294967041,


### PR DESCRIPTION
# Changelog Stamps 2.0

as a matter of versioning, rez,..., we called this 2.0 for us. Of course you can name it whatever you like :)

Merging Stamps v1.1 with Labelconnector v1.5

### changes to Stamps itself:

- changed the text on anchors/stamps to html to be able to colorize parts differently
- added new callbacks to ensure hide/disable functionality pressing D on Anchors (and preserving it's state with saving/loading)
- disabled PostageStamps by default. Defaulting to NoOps now.
- added jumpORcolor(), showConnections(), jumpKeepingPreviousSelection(), change_color_on_anchors()
- removed the check for name duplicates when creating new anchors/stamps. Nuke can do it by default with the node.setName() super fast. This improves speed quite tremendously! Collisions are still nto a problem, the new Anchor name might be just one digit apart, but that is as "collision proof" as any other random name when copying to another script.
- made some changes so the "drag node with ctrl-shift onto another node to switch their places" works now with stamps as well, without loosing their proper connections
- added USE_LABELCONNECTOR_UI constant to stamps_config.py to be able to switch between the old and new UI
- added the functionality to also derive different default colors based on e.g. naming, category, ... similar to default tags
- disabled all processing in the DeepExpression nodes used as stamps/anchors
- changed "except" to "except Exception" to comply with new Python 3 guidelines

### new UI:

implemented UI from LabelConnector

- adjusted UI to fit Stamps with Categories derived from Tags and/or Backdrops
- Top row will show all categories, Tags on the left, Backdrops on the right
- remembers previously selected category
- character based search (similar to Nuke Node Menu, e.g. "rc" can resolve "Roto Character")
- search is case insensitive
- tab or enter creates top result
- it always searches amongst all anchors, not just the selected category
- implemented Color UI from LabelConnector
- ctrl+STAMPS_SHORTCUT with one or multiple Anchors selected
- quickly change color of selected anchor
- color will be changed on all stamps accordingly
- COLOR_LIST in labelConnectorForStamps.py can be adjusted to your liking

## New Shortcuts 
(to make these even more handy, we have stamps on "E" by default. We didn't change the default in this version though, it's F8, named STAMPS_SHORTCUT)

### in the new UI:
- **right click:** temporarily set viewer to that anchor (click again or closing UI reverts to previous state)
- **shift+click:** select and create multiple
- **alt+click:** open color quick menu to colorize anchor
- **ctrl+click:** jumps to anchor or category (also works on top row of UI)
- **ctrl+alt+click:** jump/cycle through stamps

### outside of the UI:
- **ctrl+STAMPS_SHORTCUT:** with one or multiple Anchors selected, set a new color
- **ctrl+STAMPS_SHORTCUT:** with Stamp selected, will jump to it's anchor
- **shift+STAMPS_SHORTCUT:** with one or multiple anchors or stamps selected, will select all stamps of their/that anchor
- **D:** disable (hide) Anchors. They won't show up in the new UI. (e.g. you load a different shot as ref into your comp)

Best
Lukas Schwabe and Lukas Fabian