### PR TITLE
Nuke16 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Stamps
+Smart node connection system for Nuke by Adrian Pueyo and Alexey Kuchinski.
+
+## Version
+v1.2 (March 2025) - Updated for Nuke 16 compatibility
+
+## Description
+Stamps is a smart node connection system for Nuke that allows you to create linked instances of nodes. Stamps consists of Anchor stamps and Wired stamps. The Anchor is the source node and Wired stamps can be created to reference an Anchor from anywhere in the Node Graph.
+
+## Compatibility
+- Nuke 11.0 or later
+- **Now supports Nuke 16 with Python 3.11 and PySide6**
+
+## Installation
+
+1. Copy the `stamps` folder to your `.nuke` folder or any other directory in your Nuke plugin path.
+2. Add the following lines to your `menu.py` file:
+
+```python
+import nuke
+nuke.pluginAddPath("stamps")
+import stamps
+```
+
+If the plugin is stored in a subdirectory, adjust the path accordingly.
+
+## Nuke 16 Compatibility Notes
+
+The v1.2 update introduces compatibility with Nuke 16, which uses Python 3.11 and PySide6 (not PySide2 as in previous versions). The plugin has been updated to automatically use PySide6 when running in Nuke 16.
+
+If you encounter any issues with Qt import errors, please verify that:
+
+1. You're using the latest version of the plugin from the nuke16-compatibility branch
+2. The installation paths are correct in your environment
+3. Your Nuke 16 installation includes PySide6 (which should be included by default)
+
+## Documentation
+For detailed usage instructions, please refer to the included user guide: "Stamps v1.1 User Guide.pdf"
+
+## License
+See the LICENSE file for details.
+
+## Credits
+- Created by Adrian Pueyo and Alexey Kuchinski
+- Website: http://www.adrianpueyo.com
+- Nukepedia: http://www.nukepedia.com/gizmos/other/stamps
+- GitHub: https://github.com/adrianpueyo/stamps 

--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -50,23 +50,56 @@ import os
 if sys.version_info[0] >= 3:
     unicode = str
 
-# PySide import switch
-try:
-    if nuke.NUKE_VERSION_MAJOR < 11:
-        from PySide import QtCore, QtGui, QtGui as QtWidgets
-        from PySide.QtCore import Qt
-    else:
-        # For Nuke 11+ (including Nuke 16+)
-        from PySide2 import QtWidgets, QtGui, QtCore
-        from PySide2.QtCore import Qt
-except ImportError:
+# PySide import switch - updated for Nuke 16 (which uses PySide6)
+qt_imported = False
+
+# First try PySide6 (used in Nuke 16)
+if not qt_imported:
     try:
-        # For environments with Qt.py installed (common in studio pipelines)
-        from Qt import QtCore, QtGui, QtWidgets
+        from PySide6 import QtWidgets, QtGui, QtCore
+        from PySide6.QtCore import Qt
+        qt_imported = True
     except ImportError:
-        # Last resort fallback for Nuke 16+
-        from PySide2 import QtWidgets, QtGui, QtCore
-        from PySide2.QtCore import Qt
+        pass
+
+# Try traditional PySide/PySide2 based on Nuke version (for compatibility with older Nuke versions)
+if not qt_imported:
+    try:
+        if nuke.NUKE_VERSION_MAJOR < 11:
+            from PySide import QtCore, QtGui, QtGui as QtWidgets
+            from PySide.QtCore import Qt
+        else:
+            from PySide2 import QtWidgets, QtGui, QtCore
+            from PySide2.QtCore import Qt
+        qt_imported = True
+    except ImportError:
+        pass
+
+# Try Qt.py abstraction layer (common in some studio environments)
+if not qt_imported:
+    try:
+        from Qt import QtCore, QtGui, QtWidgets
+        qt_imported = True
+    except ImportError:
+        pass
+
+# Try PyQt5 as final alternative
+if not qt_imported:
+    try:
+        from PyQt5 import QtWidgets, QtGui, QtCore
+        from PyQt5.QtCore import Qt
+        qt_imported = True
+    except ImportError:
+        pass
+
+# If all else fails, raise a more informative error
+if not qt_imported:
+    error_msg = (
+        "Could not import any Qt modules (PySide6, PySide2, Qt.py, PyQt5).\n"
+        "Based on testing, Nuke 16 uses PySide6, but it wasn't found in your environment.\n"
+        "Please ensure the appropriate Qt module is available in your PYTHONPATH."
+    )
+    raise ImportError(error_msg)
 
 # Import stamps_config
 # Optional: place the stamps_config.py file anywhere in your python path (i.e. in your /.nuke folder)

--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -2,8 +2,8 @@
 # Stamps by Adrian Pueyo and Alexey Kuchinski
 # Smart node connection system for Nuke
 # adrianpueyo.com, 2018-2021
-version= "v1.1"
-date = "May 18 2021"
+version= "v1.2"
+date = "March 7 2025"
 #-----------------------------------------------------
 
 # Constants
@@ -28,7 +28,7 @@ TagsIgnoreClasses = ["NoOp", "Dot", "Reformat", "DeepReformat", "Crop"]
 AnchorClassColors = {"Camera":int('%02x%02x%02x%02x' % (255,255,255,1),16),}
 WiredClassColors = {"Camera":int('%02x%02x%02x%02x' % (51,0,0,1),16),}
 STAMPS_HELP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated "+date
-VERSION_TOOLTIP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated "+date+"."
+VERSION_TOOLTIP = "Stamps by Adrian Pueyo and Alexey Kuchinski.\nUpdated "+date+".\nNuke 16 compatible."
 STAMPS_SHORTCUT = "F8"
 KEEP_ORIGINAL_TAGS = True
 
@@ -56,10 +56,17 @@ try:
         from PySide import QtCore, QtGui, QtGui as QtWidgets
         from PySide.QtCore import Qt
     else:
+        # For Nuke 11+ (including Nuke 16+)
         from PySide2 import QtWidgets, QtGui, QtCore
         from PySide2.QtCore import Qt
 except ImportError:
-    from Qt import QtCore, QtGui, QtWidgets
+    try:
+        # For environments with Qt.py installed (common in studio pipelines)
+        from Qt import QtCore, QtGui, QtWidgets
+    except ImportError:
+        # Last resort fallback for Nuke 16+
+        from PySide2 import QtWidgets, QtGui, QtCore
+        from PySide2.QtCore import Qt
 
 # Import stamps_config
 # Optional: place the stamps_config.py file anywhere in your python path (i.e. in your /.nuke folder)
@@ -2287,14 +2294,13 @@ def showInGithub():
     from webbrowser import open as openUrl
     openUrl("https://github.com/adrianpueyo/stamps")
 
-
 def showHelp():
-     from webbrowser import open as openUrl
-     openUrl("http://www.adrianpueyo.com/Stamps_v1.1.pdf")
+    from webbrowser import open as openUrl
+    openUrl("http://www.adrianpueyo.com/Stamps_v1.2.pdf")
 
-def showVideo():        
-     from webbrowser import open as openUrl     
-     openUrl("https://vimeo.com/adrianpueyo/knobscripter2")
+def showVideo():
+    from webbrowser import open as openUrl
+    openUrl("https://vimeo.com/adrianpueyo/knobscripter2")
 
 def stampBuildMenus():
     global Stamps_MenusLoaded


### PR DESCRIPTION
Hi Adrian, I am working on migrating our pipeline to Nuke 16 and of course could not do so without having Stamps working :) What a great tool!

I have tested this branch with Nuke 16.0 on Rocky 9 Linux with Python 3.11.7

Tried to keep the changes minimal:

- Updated the import system to try PySide6 first (for Nuke 16)
- Maintained the original PySide/PySide2 logic for backwards compatibility
- Added helpful error messages to assist with troubleshooting
- Updated version number and documentation

Fixes #15 

Any questions please feel free to contact me,

Best,
George Antonopoulos