### PR TITLE
Fix headless GUI errors

### DIFF
--- a/stamps/stamps.py
+++ b/stamps/stamps.py
@@ -27,7 +27,7 @@ ANCHOR_DEFAULTS = {
 WIRED_DEFAULTS = {
     "tile_color": int('%02x%02x%02x%02x' % (1, 0, 0, 1), 16),
     "autolabel": 'nuke.thisNode().knob("title").value()',
-    "knobChanged": 'import stamps; stamps.wiredKnobChanged()'
+    "knobChanged": 'if nuke.GUI:\n    try:\n        import stamps; stamps.wiredKnobChanged()\n    except:\n        pass'
 }
 
 DeepExceptionClasses = ["DeepToImage", "DeepHoldout", "DeepHoldout2"]  # Nodes with "Deep" in their class that don't classify as Deep.
@@ -2953,5 +2953,7 @@ def goStamp(ns=""):
             except Exception:
                 continue
 
-stampBuildMenus()
+if nuke.GUI:
+    stampBuildMenus()
+
 addIncludesPath()


### PR DESCRIPTION
When artists work in Nuke GUI mode and use stamps, it creates nodes with knobChanged callbacks that import stamps.  When rendering these Nuke scripts in headless mode knobChanged is triggered, which imports stamps, which calls `stampBuildMenus`, then finally fails because of running GUI in headless mode. This should fix the issue by modifying the knobChanged callback to only import stamps if in GUI mode.

I wasn't exactly sure which branch to base off of so I decided to go with `release/v1.2.0`. Let me know if I should change this.